### PR TITLE
Implement accept_both resolution helper with strategy options

### DIFF
--- a/crates/meldr-core/src/resolution.rs
+++ b/crates/meldr-core/src/resolution.rs
@@ -41,8 +41,7 @@ fn combine_with_dedup(first: &str, second: &str, trim_whitespace: bool) -> Strin
             line.to_string()
         };
 
-        if !seen.contains(&key) {
-            seen.insert(key);
+        if seen.insert(key) {
             result_lines.push(line);
         }
     }


### PR DESCRIPTION
## Summary

- Add `accept_both()` helper method to `Resolution` struct for combining left and right conflict content
- Support configurable ordering (`LeftThenRight` / `RightThenLeft`)
- Support line deduplication with optional whitespace trimming
- Handle empty side cases (returns non-empty side)

Closes #6

## Test plan

- [x] `cargo test -p meldr-core` - all 75 tests pass including 13 new accept_both tests
- [x] `cargo clippy -p meldr-core` - no warnings
- [x] `cargo fmt --check` - formatting correct