### PR TITLE
Add vim-style navigation: gg, N, and Enter keybindings

### DIFF
--- a/crates/weavr-tui/src/ui/mod.rs
+++ b/crates/weavr-tui/src/ui/mod.rs
@@ -67,8 +67,8 @@ mod tests {
         let last_line: String = (0..buffer.area.width)
             .map(|x| buffer.cell((x, 23)).unwrap().symbol().to_string())
             .collect();
-        // Status bar shows context-sensitive help
-        assert!(last_line.contains("quit"));
+        // Status bar shows pane info
+        assert!(last_line.contains("pane"));
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Implements remaining navigation features for issue #13:

- **`gg`** - Vim-style double-press to jump to first hunk (replaces single `g`)
- **`N`** - Navigate to previous unresolved hunk (complements existing `n`)
- **`Enter`** - Direct focus to result pane
- **Status bar** - Updated format: `Hunk 2/5 | Left pane | 3 unresolved`

## Changes

- Added pending key infrastructure with 500ms timeout for multi-key sequences
- Added `prev_unresolved_hunk()` method mirroring `next_unresolved_hunk()`
- Added `focus_result()` for direct result pane focus
- Updated status bar to show hunk position, focused pane, and unresolved count

## Test plan

- [x] `cargo test -p weavr-tui` passes (82 tests)
- [x] `cargo clippy` passes with no warnings
- [ ] Manual testing with conflict file:
  - `gg` goes to first hunk
  - `G` goes to last hunk
  - `n`/`N` cycle through unresolved hunks
  - `Enter` focuses result pane
  - Status bar shows correct format

Closes #13