### PR TITLE
Add weavr-vcs crate with VcsBackend trait (Issue #86)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1951,6 +1951,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "weavr-vcs"
+version = "0.1.0"
+dependencies = [
+ "thiserror",
+]
+
+[[package]]
 name = "web-sys"
 version = "0.3.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
     "crates/weavr-git",
     "crates/weavr-ai",
     "crates/weavr-ast",
+    "crates/weavr-vcs",
 ]
 
 [workspace.package]
@@ -34,6 +35,7 @@ weavr-git = { path = "crates/weavr-git", version = "0.1.0" }
 weavr-tui = { path = "crates/weavr-tui", version = "0.1.0" }
 weavr-ai = { path = "crates/weavr-ai", version = "0.1.0" }
 weavr-ast = { path = "crates/weavr-ast", version = "0.1.0" }
+weavr-vcs = { path = "crates/weavr-vcs", version = "0.1.0" }
 
 # CLI dependencies
 clap = { version = "4.4", features = ["derive"] }

--- a/crates/weavr-vcs/Cargo.toml
+++ b/crates/weavr-vcs/Cargo.toml
@@ -1,0 +1,17 @@
+[package]
+name = "weavr-vcs"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+authors.workspace = true
+license.workspace = true
+repository.workspace = true
+description = "VCS abstraction trait for weavr - backend-agnostic version control operations"
+keywords = ["vcs", "git", "merge", "conflict"]
+categories = ["development-tools"]
+
+[lints]
+workspace = true
+
+[dependencies]
+thiserror.workspace = true

--- a/crates/weavr-vcs/src/backend.rs
+++ b/crates/weavr-vcs/src/backend.rs
@@ -1,0 +1,46 @@
+//! VCS backend trait definition.
+
+use std::path::Path;
+
+use crate::error::VcsError;
+use crate::types::{ConflictedFile, VcsOperation};
+
+/// A backend-agnostic interface to a version control system.
+///
+/// Implementations provide concrete VCS operations (Git, Jujutsu, etc.).
+/// Discovery is not part of the trait — each backend provides its own
+/// constructor, and consumers work with `Box<dyn VcsBackend>`.
+///
+/// All operations are synchronous; backends that shell out to subprocesses
+/// can use blocking calls directly.
+pub trait VcsBackend: Send + Sync {
+    /// Returns the name of this VCS backend (e.g., "git", "jj").
+    fn name(&self) -> &str;
+
+    /// Returns the root directory of the repository's working tree.
+    fn root(&self) -> &Path;
+
+    /// Returns all files with detected conflicts.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VcsError`] if the backend cannot determine conflict status.
+    fn conflicted_files(&self) -> Result<Vec<ConflictedFile>, VcsError>;
+
+    /// Stages a resolved file for the next commit.
+    ///
+    /// The `path` must be relative to the repository root, matching the paths
+    /// returned by [`conflicted_files()`](Self::conflicted_files).
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VcsError`] if staging fails.
+    fn stage_file(&self, path: &Path) -> Result<(), VcsError>;
+
+    /// Returns the current VCS operation in progress, if any.
+    ///
+    /// # Errors
+    ///
+    /// Returns [`VcsError`] if the backend cannot determine the current operation.
+    fn current_operation(&self) -> Result<VcsOperation, VcsError>;
+}

--- a/crates/weavr-vcs/src/error.rs
+++ b/crates/weavr-vcs/src/error.rs
@@ -1,0 +1,43 @@
+//! Error types for weavr-vcs.
+
+use std::path::PathBuf;
+
+use thiserror::Error;
+
+/// VCS operation errors.
+#[derive(Debug, Error)]
+pub enum VcsError {
+    /// Not inside a VCS repository.
+    #[error("not in a repository")]
+    NotInRepo,
+
+    /// Failed to discover repository root.
+    #[error("failed to discover repository: {0}")]
+    DiscoveryFailed(String),
+
+    /// VCS command execution failed.
+    #[error("command failed: {0}")]
+    CommandFailed(#[source] std::io::Error),
+
+    /// A VCS operation returned an error.
+    #[error("operation error: {0}")]
+    OperationError(String),
+
+    /// Failed to parse VCS output.
+    #[error("failed to parse output: {0}")]
+    ParseError(String),
+
+    /// File operation failed.
+    #[error("file operation failed on {path}: {source}")]
+    FileError {
+        /// The path that caused the error.
+        path: PathBuf,
+        /// The underlying IO error.
+        #[source]
+        source: std::io::Error,
+    },
+
+    /// The operation is not supported by this backend.
+    #[error("unsupported: {0}")]
+    Unsupported(String),
+}

--- a/crates/weavr-vcs/src/lib.rs
+++ b/crates/weavr-vcs/src/lib.rs
@@ -1,0 +1,27 @@
+//! weavr-vcs: VCS abstraction layer for backend-agnostic version control operations.
+//!
+//! This crate defines the [`VcsBackend`] trait and supporting types that allow
+//! weavr's CLI and TUI to work with any version control system (Git, Jujutsu, etc.)
+//! through a common interface.
+//!
+//! # Architecture
+//!
+//! - [`VcsBackend`] — trait that VCS backends implement
+//! - [`VcsOperation`] — the type of operation in progress (merge, rebase, etc.)
+//! - [`ConflictedFile`] — a file with a detected conflict and its [`ConflictKind`]
+//! - [`VcsError`] — error type for VCS operations
+//!
+//! This crate contains **only trait definitions and types** — no I/O, no concrete
+//! implementations. Backend crates (e.g., `weavr-git`, `weavr-jj`) provide the
+//! implementations.
+
+#![forbid(unsafe_code)]
+#![warn(missing_docs)]
+
+mod backend;
+mod error;
+mod types;
+
+pub use backend::VcsBackend;
+pub use error::VcsError;
+pub use types::{ConflictKind, ConflictedFile, VcsOperation};

--- a/crates/weavr-vcs/src/types.rs
+++ b/crates/weavr-vcs/src/types.rs
@@ -1,0 +1,107 @@
+//! VCS-agnostic types for conflict detection and operation tracking.
+
+use std::path::PathBuf;
+
+/// The type of VCS operation currently in progress.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum VcsOperation {
+    /// Normal state, no operation in progress.
+    None,
+    /// Merge in progress.
+    Merge,
+    /// Rebase in progress.
+    Rebase,
+    /// Cherry-pick in progress.
+    CherryPick,
+    /// Revert in progress.
+    Revert,
+    /// An operation not covered by other variants.
+    Other,
+}
+
+impl VcsOperation {
+    /// Returns true if any conflict-producing operation is in progress.
+    #[must_use]
+    pub fn has_conflicts(&self) -> bool {
+        !matches!(self, VcsOperation::None)
+    }
+}
+
+/// The kind of conflict detected in a file.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum ConflictKind {
+    /// Both sides modified the same file.
+    BothModified,
+    /// Both sides added the same file.
+    BothAdded,
+    /// Both sides deleted the same file.
+    BothDeleted,
+    /// Local side added the file, incoming side deleted it.
+    AddDelete,
+    /// Local side deleted the file, incoming side added it.
+    DeleteAdd,
+    /// File was renamed differently on each side.
+    Rename,
+    /// A conflict kind not covered by other variants.
+    Other,
+}
+
+/// A file with a detected conflict.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct ConflictedFile {
+    /// The path to the conflicted file, relative to the repository root.
+    pub path: PathBuf,
+    /// The kind of conflict.
+    pub kind: ConflictKind,
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn none_has_no_conflicts() {
+        assert!(!VcsOperation::None.has_conflicts());
+    }
+
+    #[test]
+    fn merge_has_conflicts() {
+        assert!(VcsOperation::Merge.has_conflicts());
+    }
+
+    #[test]
+    fn rebase_has_conflicts() {
+        assert!(VcsOperation::Rebase.has_conflicts());
+    }
+
+    #[test]
+    fn cherry_pick_has_conflicts() {
+        assert!(VcsOperation::CherryPick.has_conflicts());
+    }
+
+    #[test]
+    fn revert_has_conflicts() {
+        assert!(VcsOperation::Revert.has_conflicts());
+    }
+
+    #[test]
+    fn other_has_conflicts() {
+        assert!(VcsOperation::Other.has_conflicts());
+    }
+
+    #[test]
+    fn conflicted_file_stores_path_and_kind() {
+        let file = ConflictedFile {
+            path: PathBuf::from("src/main.rs"),
+            kind: ConflictKind::BothModified,
+        };
+        assert_eq!(file.path, PathBuf::from("src/main.rs"));
+        assert_eq!(file.kind, ConflictKind::BothModified);
+    }
+
+    #[test]
+    fn conflict_kind_equality() {
+        assert_eq!(ConflictKind::AddDelete, ConflictKind::AddDelete);
+        assert_ne!(ConflictKind::AddDelete, ConflictKind::DeleteAdd);
+    }
+}


### PR DESCRIPTION
## Summary

- Introduces the `weavr-vcs` crate with a `VcsBackend` trait that abstracts VCS operations (Git, Jujutsu, etc.) behind a common interface
- Defines VCS-agnostic types: `VcsOperation`, `ConflictKind`, `ConflictedFile`
- Defines `VcsError` enum for backend-agnostic error handling
- Contains **only trait definitions and types** — no I/O, no concrete implementations

This is the foundation for jj support, unlocking issues #87–#92. The CLI/TUI can work with `Box<dyn VcsBackend>` once `weavr-git` implements the trait (#89).

## Design Decisions

- **Sync trait** — all current VCS operations are local subprocess calls; no need for async
- **Discovery not on trait** — each backend provides its own constructor (not object-safe), consumers get `Box<dyn VcsBackend>`
- **Single `conflicted_files()` method** — returns `Vec<ConflictedFile>` (the richer type), replacing `GitRepo`'s split `conflicted_files()`/`conflicted_entries()`
- **`current_operation()` returns `Result`** — Git's impl is infallible today, but other backends may need to run commands
- **Matches existing patterns** — `Send + Sync` bounds (like `AstMerger`), `thiserror` errors, `#![forbid(unsafe_code)]`, `#![warn(missing_docs)]`

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (8 new tests in weavr-vcs, 462 total)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [x] `cargo doc --workspace --no-deps`

Closes #86