### PR TITLE
Implement VcsBackend trait for GitRepo, refactor CLI to dyn VcsBackend (Issue #89)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1916,6 +1916,7 @@ dependencies = [
  "weavr-core",
  "weavr-git",
  "weavr-tui",
+ "weavr-vcs",
 ]
 
 [[package]]
@@ -1933,6 +1934,7 @@ version = "0.1.0"
 dependencies = [
  "tempfile",
  "thiserror",
+ "weavr-vcs",
 ]
 
 [[package]]

--- a/crates/weavr-cli/Cargo.toml
+++ b/crates/weavr-cli/Cargo.toml
@@ -34,6 +34,7 @@ ast-all = ["ast-rust", "ast-csharp", "ast-typescript", "ast-go"]
 [dependencies]
 weavr-core.workspace = true
 weavr-git.workspace = true
+weavr-vcs.workspace = true
 weavr-tui.workspace = true
 clap.workspace = true
 thiserror.workspace = true

--- a/crates/weavr-cli/src/discovery.rs
+++ b/crates/weavr-cli/src/discovery.rs
@@ -1,16 +1,15 @@
-//! Git conflict file discovery.
+//! VCS conflict file discovery.
 
 use std::path::{Path, PathBuf};
 
-use weavr_git::GitRepo;
+use weavr_vcs::VcsBackend;
 
 use crate::error::CliError;
 
-/// Discovers files with Git merge conflicts in the current repository.
-pub fn discover_conflicted_files() -> Result<Vec<PathBuf>, CliError> {
-    let repo = GitRepo::discover()?;
-    let files = repo.conflicted_files()?;
-    Ok(files)
+/// Discovers files with merge conflicts using the given VCS backend.
+pub fn discover_conflicted_files(backend: &dyn VcsBackend) -> Result<Vec<PathBuf>, CliError> {
+    let files = backend.conflicted_files()?;
+    Ok(files.into_iter().map(|f| f.path).collect())
 }
 
 /// Checks if a file contains conflict markers.
@@ -19,10 +18,14 @@ pub fn has_conflict_markers(path: &Path) -> Result<bool, CliError> {
     Ok(content.contains("<<<<<<<") && content.contains("=======") && content.contains(">>>>>>>"))
 }
 
-/// Filters provided paths to only those with conflicts, or discovers all.
-pub fn resolve_files(provided: Vec<PathBuf>) -> Result<Vec<PathBuf>, CliError> {
+/// Filters provided paths to only those with conflicts, or discovers all via `backend`.
+pub fn resolve_files(
+    provided: Vec<PathBuf>,
+    backend: Option<&dyn VcsBackend>,
+) -> Result<Vec<PathBuf>, CliError> {
     if provided.is_empty() {
-        let files = discover_conflicted_files()?;
+        let backend = backend.ok_or(CliError::Vcs(weavr_vcs::VcsError::NotInRepo))?;
+        let files = discover_conflicted_files(backend)?;
         if files.is_empty() {
             return Err(CliError::NoConflictedFiles);
         }
@@ -46,8 +49,8 @@ pub fn resolve_files(provided: Vec<PathBuf>) -> Result<Vec<PathBuf>, CliError> {
 }
 
 /// Lists conflicted files to stdout.
-pub fn list_conflicted_files() -> Result<(), CliError> {
-    let files = discover_conflicted_files()?;
+pub fn list_conflicted_files(backend: &dyn VcsBackend) -> Result<(), CliError> {
+    let files = discover_conflicted_files(backend)?;
 
     if files.is_empty() {
         println!("No conflicted files found");

--- a/crates/weavr-cli/src/error.rs
+++ b/crates/weavr-cli/src/error.rs
@@ -32,6 +32,9 @@ pub enum CliError {
     #[error("Git error: {0}")]
     Git(#[from] weavr_git::GitError),
 
+    #[error("VCS error: {0}")]
+    Vcs(#[from] weavr_vcs::VcsError),
+
     #[error("Resolution error: {0}")]
     Resolution(#[from] weavr_core::ResolutionError),
 

--- a/crates/weavr-cli/src/main.rs
+++ b/crates/weavr-cli/src/main.rs
@@ -16,14 +16,29 @@ mod tui;
 
 use clap::Parser;
 
+use weavr_vcs::VcsBackend;
+
 use cli::Cli;
 use config::WeavrConfig;
 use error::{exit_codes, CliError};
 
+/// Discovers the VCS backend (currently only Git).
+fn discover_backend() -> Option<Box<dyn VcsBackend>> {
+    match weavr_git::GitRepo::discover() {
+        Ok(repo) => Some(Box::new(repo)),
+        Err(_) => None,
+    }
+}
+
 fn run(cli: &Cli) -> Result<i32, CliError> {
+    let backend = discover_backend();
+
     // Mode: List conflicted files
     if cli.list {
-        discovery::list_conflicted_files()?;
+        let backend = backend
+            .as_deref()
+            .ok_or(CliError::Vcs(weavr_vcs::VcsError::NotInRepo))?;
+        discovery::list_conflicted_files(backend)?;
         return Ok(exit_codes::SUCCESS);
     }
 
@@ -52,19 +67,12 @@ fn run(cli: &Cli) -> Result<i32, CliError> {
         config.stage_prompt = false;
     }
 
-    // Resolve which files to process
-    let files = discovery::resolve_files(cli.files.clone())?;
+    if backend.is_none() && (config.auto_stage || config.stage_prompt) {
+        eprintln!("weavr: VCS backend not found, staging disabled");
+    }
 
-    // Git repo discovery (needed for auto-staging, prompts, and explicit :wa)
-    let repo = match weavr_git::GitRepo::discover() {
-        Ok(r) => Some(r),
-        Err(e) => {
-            if config.auto_stage || config.stage_prompt {
-                eprintln!("weavr: git repo not found, staging disabled: {e}");
-            }
-            None
-        }
-    };
+    // Resolve which files to process
+    let files = discovery::resolve_files(cli.files.clone(), backend.as_deref())?;
 
     // Mode: Headless
     if cli.headless {
@@ -86,8 +94,8 @@ fn run(cli: &Cli) -> Result<i32, CliError> {
             headless::write_or_print(&result, cli.dry_run)?;
 
             if config.auto_stage && !cli.dry_run {
-                if let Some(ref repo) = repo {
-                    match repo.stage_file(path) {
+                if let Some(ref backend) = backend {
+                    match backend.stage_file(path) {
                         Ok(()) => println!("{}: staged", path.display()),
                         Err(e) => eprintln!("{}: staging failed: {e}", path.display()),
                     }
@@ -113,14 +121,14 @@ fn run(cli: &Cli) -> Result<i32, CliError> {
 
             let should_stage = config.auto_stage || result.stage_requested;
             if should_stage {
-                if let Some(ref repo) = repo {
-                    match repo.stage_file(&result.path) {
+                if let Some(ref backend) = backend {
+                    match backend.stage_file(&result.path) {
                         Ok(()) => println!("{}: staged", result.path.display()),
                         Err(e) => eprintln!("{}: staging failed: {e}", result.path.display()),
                     }
                 } else if result.stage_requested {
                     eprintln!(
-                        "{}: staging requested but git repo not available",
+                        "{}: staging requested but VCS backend not available",
                         result.path.display()
                     );
                 }

--- a/crates/weavr-git/Cargo.toml
+++ b/crates/weavr-git/Cargo.toml
@@ -15,6 +15,7 @@ workspace = true
 
 [dependencies]
 thiserror.workspace = true
+weavr-vcs.workspace = true
 
 [dev-dependencies]
 tempfile = "3"

--- a/crates/weavr-git/src/error.rs
+++ b/crates/weavr-git/src/error.rs
@@ -40,3 +40,48 @@ pub enum GitError {
         source: std::io::Error,
     },
 }
+
+impl From<GitError> for weavr_vcs::VcsError {
+    fn from(err: GitError) -> Self {
+        match err {
+            GitError::NotGitRepo => Self::NotInRepo,
+            GitError::DiscoveryFailed(msg) => Self::DiscoveryFailed(msg),
+            GitError::CommandFailed(io) => Self::CommandFailed(io),
+            GitError::CommandError { stderr } => Self::OperationError(stderr),
+            GitError::ParseError(msg) => Self::ParseError(msg),
+            GitError::FileError { path, source } => Self::FileError { path, source },
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn not_git_repo_converts_to_not_in_repo() {
+        let vcs_err: weavr_vcs::VcsError = GitError::NotGitRepo.into();
+        assert!(matches!(vcs_err, weavr_vcs::VcsError::NotInRepo));
+    }
+
+    #[test]
+    fn discovery_failed_converts() {
+        let vcs_err: weavr_vcs::VcsError = GitError::DiscoveryFailed("bad path".into()).into();
+        assert!(matches!(vcs_err, weavr_vcs::VcsError::DiscoveryFailed(msg) if msg == "bad path"));
+    }
+
+    #[test]
+    fn command_error_converts_to_operation_error() {
+        let vcs_err: weavr_vcs::VcsError = GitError::CommandError {
+            stderr: "fatal".into(),
+        }
+        .into();
+        assert!(matches!(vcs_err, weavr_vcs::VcsError::OperationError(msg) if msg == "fatal"));
+    }
+
+    #[test]
+    fn parse_error_converts() {
+        let vcs_err: weavr_vcs::VcsError = GitError::ParseError("bad output".into()).into();
+        assert!(matches!(vcs_err, weavr_vcs::VcsError::ParseError(msg) if msg == "bad output"));
+    }
+}

--- a/crates/weavr-git/src/lib.rs
+++ b/crates/weavr-git/src/lib.rs
@@ -33,3 +33,6 @@ pub use error::GitError;
 pub use porcelain::{ConflictEntry, ConflictType};
 pub use repo::GitRepo;
 pub use state::GitOperation;
+
+// Re-export VcsBackend types for convenience.
+pub use weavr_vcs::{ConflictKind, ConflictedFile, VcsBackend, VcsError, VcsOperation};

--- a/crates/weavr-git/src/porcelain.rs
+++ b/crates/weavr-git/src/porcelain.rs
@@ -2,6 +2,8 @@
 
 use std::path::PathBuf;
 
+use weavr_vcs::ConflictKind;
+
 /// Conflict type from git status porcelain output.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum ConflictType {
@@ -24,6 +26,18 @@ pub struct ConflictEntry {
     pub path: PathBuf,
     /// The type of conflict.
     pub conflict_type: ConflictType,
+}
+
+impl From<ConflictType> for ConflictKind {
+    fn from(ct: ConflictType) -> Self {
+        match ct {
+            ConflictType::BothModified => Self::BothModified,
+            ConflictType::BothAdded => Self::BothAdded,
+            ConflictType::BothDeleted => Self::BothDeleted,
+            ConflictType::AddedByUsDeletedByThem => Self::AddDelete,
+            ConflictType::AddedByThemDeletedByUs => Self::DeleteAdd,
+        }
+    }
 }
 
 /// Parses `git status --porcelain=v1` output and extracts conflicted files.
@@ -284,5 +298,45 @@ mod tests {
         let entries = parse_porcelain_v1(output);
         assert_eq!(entries.len(), 1);
         assert_eq!(entries[0].path, PathBuf::from("file with \"quotes\".rs"));
+    }
+
+    #[test]
+    fn both_modified_converts_to_conflict_kind() {
+        assert_eq!(
+            ConflictKind::from(ConflictType::BothModified),
+            ConflictKind::BothModified
+        );
+    }
+
+    #[test]
+    fn both_added_converts_to_conflict_kind() {
+        assert_eq!(
+            ConflictKind::from(ConflictType::BothAdded),
+            ConflictKind::BothAdded
+        );
+    }
+
+    #[test]
+    fn both_deleted_converts_to_conflict_kind() {
+        assert_eq!(
+            ConflictKind::from(ConflictType::BothDeleted),
+            ConflictKind::BothDeleted
+        );
+    }
+
+    #[test]
+    fn added_by_us_converts_to_add_delete() {
+        assert_eq!(
+            ConflictKind::from(ConflictType::AddedByUsDeletedByThem),
+            ConflictKind::AddDelete
+        );
+    }
+
+    #[test]
+    fn added_by_them_converts_to_delete_add() {
+        assert_eq!(
+            ConflictKind::from(ConflictType::AddedByThemDeletedByUs),
+            ConflictKind::DeleteAdd
+        );
     }
 }

--- a/crates/weavr-git/src/repo.rs
+++ b/crates/weavr-git/src/repo.rs
@@ -3,6 +3,8 @@
 use std::path::{Path, PathBuf};
 use std::process::Command;
 
+use weavr_vcs::{ConflictedFile, VcsBackend, VcsError, VcsOperation};
+
 use crate::error::GitError;
 use crate::porcelain::{parse_porcelain_v1, ConflictEntry};
 use crate::state::GitOperation;
@@ -186,5 +188,35 @@ impl GitRepo {
         }
 
         Ok(String::from_utf8_lossy(&output.stdout).into_owned())
+    }
+}
+
+impl VcsBackend for GitRepo {
+    #[allow(clippy::unnecessary_literal_bound)]
+    fn name(&self) -> &str {
+        "git"
+    }
+
+    fn root(&self) -> &Path {
+        &self.root
+    }
+
+    fn conflicted_files(&self) -> Result<Vec<ConflictedFile>, VcsError> {
+        let entries = self.conflicted_entries().map_err(VcsError::from)?;
+        Ok(entries
+            .into_iter()
+            .map(|e| ConflictedFile {
+                path: e.path,
+                kind: e.conflict_type.into(),
+            })
+            .collect())
+    }
+
+    fn stage_file(&self, path: &Path) -> Result<(), VcsError> {
+        GitRepo::stage_file(self, path).map_err(VcsError::from)
+    }
+
+    fn current_operation(&self) -> Result<VcsOperation, VcsError> {
+        Ok(GitRepo::current_operation(self).into())
     }
 }

--- a/crates/weavr-git/src/state.rs
+++ b/crates/weavr-git/src/state.rs
@@ -23,6 +23,18 @@ impl GitOperation {
     }
 }
 
+impl From<GitOperation> for weavr_vcs::VcsOperation {
+    fn from(op: GitOperation) -> Self {
+        match op {
+            GitOperation::None => Self::None,
+            GitOperation::Merge => Self::Merge,
+            GitOperation::Rebase => Self::Rebase,
+            GitOperation::CherryPick => Self::CherryPick,
+            GitOperation::Revert => Self::Revert,
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -50,5 +62,45 @@ mod tests {
     #[test]
     fn revert_has_conflicts() {
         assert!(GitOperation::Revert.has_conflicts());
+    }
+
+    #[test]
+    fn none_converts_to_vcs_none() {
+        assert_eq!(
+            weavr_vcs::VcsOperation::from(GitOperation::None),
+            weavr_vcs::VcsOperation::None
+        );
+    }
+
+    #[test]
+    fn merge_converts_to_vcs_merge() {
+        assert_eq!(
+            weavr_vcs::VcsOperation::from(GitOperation::Merge),
+            weavr_vcs::VcsOperation::Merge
+        );
+    }
+
+    #[test]
+    fn rebase_converts_to_vcs_rebase() {
+        assert_eq!(
+            weavr_vcs::VcsOperation::from(GitOperation::Rebase),
+            weavr_vcs::VcsOperation::Rebase
+        );
+    }
+
+    #[test]
+    fn cherry_pick_converts_to_vcs_cherry_pick() {
+        assert_eq!(
+            weavr_vcs::VcsOperation::from(GitOperation::CherryPick),
+            weavr_vcs::VcsOperation::CherryPick
+        );
+    }
+
+    #[test]
+    fn revert_converts_to_vcs_revert() {
+        assert_eq!(
+            weavr_vcs::VcsOperation::from(GitOperation::Revert),
+            weavr_vcs::VcsOperation::Revert
+        );
     }
 }

--- a/crates/weavr-git/tests/integration_tests.rs
+++ b/crates/weavr-git/tests/integration_tests.rs
@@ -4,7 +4,7 @@ use std::fs;
 use std::path::PathBuf;
 use std::process::Command;
 use tempfile::TempDir;
-use weavr_git::{GitOperation, GitRepo};
+use weavr_git::{ConflictKind, GitOperation, GitRepo, VcsBackend, VcsOperation};
 
 /// Helper to create a Git repository in a temp directory.
 fn setup_git_repo() -> TempDir {
@@ -342,4 +342,116 @@ fn conflicted_entries_returns_conflict_types() {
         entries[0].conflict_type,
         weavr_git::ConflictType::BothModified
     );
+}
+
+// --- VcsBackend trait integration tests ---
+
+/// Helper to create a merge conflict and return the temp dir and `GitRepo`.
+fn setup_merge_conflict() -> (TempDir, GitRepo) {
+    let dir = setup_git_repo();
+
+    commit_file(&dir, "file.txt", "initial", "Initial commit");
+
+    Command::new("git")
+        .args(["checkout", "-b", "feature"])
+        .current_dir(dir.path())
+        .output()
+        .expect("create branch");
+    commit_file(&dir, "file.txt", "feature change", "Feature commit");
+
+    Command::new("git")
+        .args(["checkout", "main"])
+        .current_dir(dir.path())
+        .output()
+        .expect("checkout main");
+    commit_file(&dir, "file.txt", "main change", "Main commit");
+
+    let merge_output = Command::new("git")
+        .args(["merge", "feature"])
+        .current_dir(dir.path())
+        .output()
+        .expect("git merge feature");
+    assert!(
+        !merge_output.status.success(),
+        "expected 'git merge feature' to produce a conflict (non-zero exit status), \
+stdout: {}, stderr: {}",
+        String::from_utf8_lossy(&merge_output.stdout),
+        String::from_utf8_lossy(&merge_output.stderr)
+    );
+
+    let repo = GitRepo::discover_from(dir.path()).expect("discover repo");
+    (dir, repo)
+}
+
+#[test]
+fn vcs_backend_name_returns_git() {
+    let dir = setup_git_repo();
+    commit_file(&dir, "file.txt", "content", "Initial commit");
+    let repo = GitRepo::discover_from(dir.path()).expect("discover repo");
+    let backend: &dyn VcsBackend = &repo;
+    assert_eq!(backend.name(), "git");
+}
+
+#[test]
+fn vcs_backend_root_matches_repo_root() {
+    let dir = setup_git_repo();
+    commit_file(&dir, "file.txt", "content", "Initial commit");
+    let repo = GitRepo::discover_from(dir.path()).expect("discover repo");
+    let backend: &dyn VcsBackend = &repo;
+    assert_eq!(
+        canonicalize_for_comparison(backend.root()),
+        canonicalize_for_comparison(dir.path())
+    );
+}
+
+#[test]
+fn vcs_backend_conflicted_files_returns_correct_kind() {
+    let (_dir, repo) = setup_merge_conflict();
+    let backend: &dyn VcsBackend = &repo;
+
+    let files = backend.conflicted_files().expect("get conflicted files");
+    assert_eq!(files.len(), 1);
+    assert_eq!(files[0].path, PathBuf::from("file.txt"));
+    assert_eq!(files[0].kind, ConflictKind::BothModified);
+}
+
+#[test]
+fn vcs_backend_current_operation_during_merge() {
+    let (_dir, repo) = setup_merge_conflict();
+    let backend: &dyn VcsBackend = &repo;
+
+    let op = backend.current_operation().expect("get current operation");
+    assert_eq!(op, VcsOperation::Merge);
+}
+
+#[test]
+fn vcs_backend_current_operation_when_clean() {
+    let dir = setup_git_repo();
+    commit_file(&dir, "file.txt", "content", "Initial commit");
+    let repo = GitRepo::discover_from(dir.path()).expect("discover repo");
+    let backend: &dyn VcsBackend = &repo;
+
+    let op = backend.current_operation().expect("get current operation");
+    assert_eq!(op, VcsOperation::None);
+}
+
+#[test]
+fn vcs_backend_stage_file_clears_conflict() {
+    let (dir, repo) = setup_merge_conflict();
+    let backend: &dyn VcsBackend = &repo;
+
+    // Verify conflict exists
+    let before = backend.conflicted_files().expect("get conflicts");
+    assert_eq!(before.len(), 1);
+
+    // Resolve and stage via VcsBackend
+    let file_path = dir.path().join("file.txt");
+    fs::write(&file_path, "resolved content").expect("write resolved");
+    backend
+        .stage_file(&PathBuf::from("file.txt"))
+        .expect("stage file");
+
+    // Conflict should be cleared
+    let after = backend.conflicted_files().expect("get conflicts");
+    assert!(after.is_empty());
 }


### PR DESCRIPTION
## Summary

- Implements `VcsBackend` trait for `GitRepo` with `From` conversions for all error, conflict, and operation types (`GitError → VcsError`, `ConflictType → ConflictKind`, `GitOperation → VcsOperation`)
- Refactors CLI to discover and use `Box<dyn VcsBackend>` instead of concrete `GitRepo`, making it backend-agnostic
- Re-exports `VcsBackend` types from `weavr-git` for convenience
- Adds 20 new tests (14 unit + 6 integration) covering all conversions and trait methods

## Test plan

- [x] `cargo fmt --all --check` passes
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo test --workspace` — all 487 tests pass (20 new)
- [ ] Verify `weavr --list` works in a repo with conflicts
- [ ] Verify headless and TUI modes stage files correctly via the trait interface

Closes #89