### PR TITLE
Add partial save support: write files with remaining conflict markers

### DIFF
--- a/crates/weavr-cli/src/main.rs
+++ b/crates/weavr-cli/src/main.rs
@@ -136,24 +136,37 @@ fn run(cli: &Cli) -> Result<i32, CliError> {
     for result in &results {
         if let Some(ref content) = result.content {
             std::fs::write(&result.path, content)?;
-            println!(
-                "{}: {} hunks resolved",
-                result.path.display(),
-                result.hunks_resolved
-            );
 
-            let should_stage = config.auto_stage || result.stage_requested;
-            if should_stage {
-                if let Some(ref backend) = backend {
-                    match backend.stage_file(&result.path) {
-                        Ok(()) => println!("{}: staged", result.path.display()),
-                        Err(e) => eprintln!("{}: staging failed: {e}", result.path.display()),
+            if result.is_partial {
+                // Partial write — conflict markers remain
+                let remaining = result.total_hunks - result.hunks_resolved;
+                println!(
+                    "{}: saved with {} unresolved hunks (markers preserved)",
+                    result.path.display(),
+                    remaining
+                );
+                any_unresolved = true;
+                // Do NOT auto-stage — file still has conflict markers
+            } else {
+                println!(
+                    "{}: {} hunks resolved",
+                    result.path.display(),
+                    result.hunks_resolved
+                );
+
+                let should_stage = config.auto_stage || result.stage_requested;
+                if should_stage {
+                    if let Some(ref backend) = backend {
+                        match backend.stage_file(&result.path) {
+                            Ok(()) => println!("{}: staged", result.path.display()),
+                            Err(e) => eprintln!("{}: staging failed: {e}", result.path.display()),
+                        }
+                    } else if result.stage_requested {
+                        eprintln!(
+                            "{}: staging requested but VCS backend not available",
+                            result.path.display()
+                        );
                     }
-                } else if result.stage_requested {
-                    eprintln!(
-                        "{}: staging requested but VCS backend not available",
-                        result.path.display()
-                    );
                 }
             }
         } else {

--- a/crates/weavr-cli/src/tui.rs
+++ b/crates/weavr-cli/src/tui.rs
@@ -20,6 +20,8 @@ pub struct TuiResult {
     pub total_hunks: usize,
     /// Whether the user requested staging (via `:wa` or staging prompt).
     pub stage_requested: bool,
+    /// Whether this is a partial write (some hunks still have conflict markers).
+    pub is_partial: bool,
 }
 
 /// Runs the TUI for a single file.
@@ -41,6 +43,7 @@ pub fn process_file(
             hunks_resolved: 0,
             total_hunks: 0,
             stage_requested: false,
+            is_partial: false,
         });
     }
 
@@ -86,8 +89,9 @@ pub fn process_file(
     // Run TUI event loop
     weavr_tui::run(&mut app)?;
 
-    // Extract staging preference before taking session
+    // Extract preferences before taking session
     let stage_requested = app.stage_requested();
+    let partial_write = app.partial_write_requested();
 
     // Extract session and check resolution state
     let session = app
@@ -112,6 +116,19 @@ pub fn process_file(
             hunks_resolved: result.summary.resolved_hunks,
             total_hunks,
             stage_requested,
+            is_partial: false,
+        })
+    } else if partial_write {
+        // Partial write — use apply_partial to preserve unresolved markers
+        let result = session.apply_partial()?;
+
+        Ok(TuiResult {
+            path: path.to_path_buf(),
+            content: Some(result.content),
+            hunks_resolved: result.summary.resolved_hunks,
+            total_hunks,
+            stage_requested: false,
+            is_partial: true,
         })
     } else {
         // User quit without resolving all hunks
@@ -121,6 +138,7 @@ pub fn process_file(
             hunks_resolved: resolved_count,
             total_hunks,
             stage_requested: false,
+            is_partial: false,
         })
     }
 }
@@ -130,6 +148,7 @@ pub fn process_file(
 /// Files without conflicts are returned immediately as resolved `TuiResult`s.
 /// If only one file has conflicts, delegates to `process_file`.
 /// Otherwise, creates a multi-file workspace for the TUI.
+#[allow(clippy::too_many_lines)]
 pub fn process_files(
     paths: &[PathBuf],
     config: &WeavrConfig,
@@ -153,6 +172,7 @@ pub fn process_files(
                 hunks_resolved: 0,
                 total_hunks: 0,
                 stage_requested: false,
+                is_partial: false,
             });
         } else {
             conflicted.push((path.clone(), session));
@@ -244,6 +264,19 @@ pub fn process_files(
                     hunks_resolved: merge_result.summary.resolved_hunks,
                     total_hunks,
                     stage_requested: file_state.stage_requested,
+                    is_partial: false,
+                });
+            } else if file_state.written && file_state.partial {
+                // Partial write — use apply_partial
+                let result = file_state.session.apply_partial()?;
+
+                results.push(TuiResult {
+                    path: file_state.path,
+                    content: Some(result.content),
+                    hunks_resolved: result.summary.resolved_hunks,
+                    total_hunks,
+                    stage_requested: false,
+                    is_partial: true,
                 });
             } else {
                 // User didn't complete this file
@@ -253,6 +286,7 @@ pub fn process_files(
                     hunks_resolved: resolved_count,
                     total_hunks,
                     stage_requested: false,
+                    is_partial: false,
                 });
             }
         }

--- a/crates/weavr-core/src/hunk.rs
+++ b/crates/weavr-core/src/hunk.rs
@@ -66,6 +66,10 @@ pub struct ConflictHunk {
     pub context: HunkContext,
     /// Resolution state.
     pub state: HunkState,
+    /// The verbatim original conflict marker text (from `<<<<<<<` through `>>>>>>>`).
+    /// Used for partial save to preserve unresolved hunks with perfect fidelity.
+    #[serde(default)]
+    pub original_text: Option<String>,
 }
 
 impl ConflictHunk {
@@ -91,6 +95,7 @@ impl ConflictHunk {
             extra_bases: vec![],
             context,
             state,
+            original_text: None,
         }
     }
 
@@ -207,6 +212,7 @@ mod tests {
             extra_bases: vec![],
             context: HunkContext::default(),
             state: HunkState::default(),
+            original_text: None,
         }
     }
 

--- a/crates/weavr-core/src/parser.rs
+++ b/crates/weavr-core/src/parser.rs
@@ -219,6 +219,9 @@ fn parse_git_markers(content: &str) -> Result<ParsedConflict, ParseError> {
                     .map(|s| (*s).to_string())
                     .collect();
 
+                // Capture the verbatim conflict marker text for partial save
+                let original_text = lines[hunk_start_line - 1..=line_num].join("\n");
+
                 // Build the hunk
                 let hunk = ConflictHunk {
                     id: HunkId(hunk_id_counter),
@@ -240,6 +243,7 @@ fn parse_git_markers(content: &str) -> Result<ParsedConflict, ParseError> {
                         start_line_right: right_content_start,
                     },
                     state: HunkState::Unresolved,
+                    original_text: Some(original_text),
                 };
 
                 let hunk_index = hunks.len();
@@ -470,6 +474,9 @@ fn parse_jj_snapshot_markers(content: &str) -> Result<ParsedConflict, ParseError
                     .map(|s| (*s).to_string())
                     .collect();
 
+                // Capture the verbatim conflict marker text for partial save
+                let original_text = lines[hunk_start_line - 1..=line_num].join("\n");
+
                 let hunk = ConflictHunk {
                     id: HunkId(hunk_id_counter),
                     left: HunkContent {
@@ -490,6 +497,7 @@ fn parse_jj_snapshot_markers(content: &str) -> Result<ParsedConflict, ParseError
                         start_line_right: side2_content_start,
                     },
                     state: HunkState::Unresolved,
+                    original_text: Some(original_text),
                 };
 
                 let hunk_index = hunks.len();
@@ -878,6 +886,9 @@ fn parse_jj_diff_markers(content: &str) -> Result<ParsedConflict, ParseError> {
                     (left_text, right_text, Some(base1))
                 };
 
+                // Capture the verbatim conflict marker text for partial save
+                let original_text = lines[hunk_start_line - 1..=line_num].join("\n");
+
                 let hunk = ConflictHunk {
                     id: HunkId(hunk_id_counter),
                     left: HunkContent { text: left },
@@ -892,6 +903,7 @@ fn parse_jj_diff_markers(content: &str) -> Result<ParsedConflict, ParseError> {
                         start_line_right: section2_content_start,
                     },
                     state: HunkState::Unresolved,
+                    original_text: Some(original_text),
                 };
 
                 let hunk_index = hunks.len();
@@ -1931,5 +1943,62 @@ after";
         assert!(matches!(&result.segments[0], Segment::Clean(s) if s == "before"));
         assert!(matches!(&result.segments[1], Segment::Conflict(0)));
         assert!(matches!(&result.segments[2], Segment::Clean(s) if s == "after"));
+    }
+
+    #[test]
+    fn original_text_captured_git_2way() {
+        let content = "before\n<<<<<<< HEAD\nleft\n=======\nright\n>>>>>>> feature\nafter";
+        let result = parse_conflict_markers(content).unwrap();
+        assert_eq!(result.hunks.len(), 1);
+        let expected = "<<<<<<< HEAD\nleft\n=======\nright\n>>>>>>> feature";
+        assert_eq!(result.hunks[0].original_text.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn original_text_captured_git_diff3() {
+        let content =
+            "before\n<<<<<<< HEAD\nleft\n||||||| base\nbase\n=======\nright\n>>>>>>> feature\nafter";
+        let result = parse_conflict_markers(content).unwrap();
+        assert_eq!(result.hunks.len(), 1);
+        let expected = "<<<<<<< HEAD\nleft\n||||||| base\nbase\n=======\nright\n>>>>>>> feature";
+        assert_eq!(result.hunks[0].original_text.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn original_text_captured_jj_snapshot() {
+        let content = "before\n<<<<<<< Conflict 1 of 1\n+++++++ Side #1\nleft\n+++++++ Side #2\nright\n>>>>>>> Conflict 1 of 1\nafter";
+        let result = parse_conflict_markers(content).unwrap();
+        assert_eq!(result.hunks.len(), 1);
+        let expected = "<<<<<<< Conflict 1 of 1\n+++++++ Side #1\nleft\n+++++++ Side #2\nright\n>>>>>>> Conflict 1 of 1";
+        assert_eq!(result.hunks[0].original_text.as_deref(), Some(expected));
+    }
+
+    #[test]
+    fn original_text_captured_jj_diff() {
+        let content = concat!(
+            "before\n",
+            "<<<<<<< Conflict 1 of 1\n",
+            "+++++++ Side #1\n",
+            "left\n",
+            "%%%%%%% Side #2\n",
+            " base\n",
+            "-base\n",
+            "+right\n",
+            ">>>>>>> Conflict 1 of 1\n",
+            "after",
+        );
+        let result = parse_conflict_markers(content).unwrap();
+        assert_eq!(result.hunks.len(), 1);
+        let expected = concat!(
+            "<<<<<<< Conflict 1 of 1\n",
+            "+++++++ Side #1\n",
+            "left\n",
+            "%%%%%%% Side #2\n",
+            " base\n",
+            "-base\n",
+            "+right\n",
+            ">>>>>>> Conflict 1 of 1",
+        );
+        assert_eq!(result.hunks[0].original_text.as_deref(), Some(expected));
     }
 }

--- a/crates/weavr-core/src/resolution.rs
+++ b/crates/weavr-core/src/resolution.rs
@@ -303,6 +303,7 @@ mod tests {
             extra_bases: vec![],
             context: HunkContext::default(),
             state: HunkState::default(),
+            original_text: None,
         }
     }
 

--- a/crates/weavr-core/src/result.rs
+++ b/crates/weavr-core/src/result.rs
@@ -37,6 +37,19 @@ pub struct MergeResult {
     pub summary: MergeSummary,
 }
 
+/// Result of a partial apply — resolved hunks are replaced, unresolved hunks
+/// retain their original conflict markers.
+#[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
+pub struct PartialApplyResult {
+    /// The file content with resolved hunks replaced and unresolved hunks
+    /// preserved as their original conflict markers.
+    pub content: String,
+    /// IDs of hunks that remain unresolved.
+    pub unresolved_hunks: Vec<HunkId>,
+    /// Statistics summary.
+    pub summary: MergeSummary,
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;

--- a/crates/weavr-core/src/session.rs
+++ b/crates/weavr-core/src/session.rs
@@ -10,7 +10,7 @@ use serde::{Deserialize, Serialize};
 use crate::{
     parse_conflict_markers, ApplyError, CompletionError, ConflictHunk, FileVersion, HunkId,
     HunkState, LifecycleError, MergeInput, MergeResult, MergeSummary, ParseError, ParsedConflict,
-    Resolution, ResolutionError, Segment, ValidationError,
+    PartialApplyResult, Resolution, ResolutionError, Segment, ValidationError,
 };
 
 /// The state of a merge session.
@@ -455,6 +455,72 @@ impl MergeSession {
             content,
             unresolved_hunks: vec![],
             warnings: vec![],
+            summary: MergeSummary {
+                total_hunks,
+                resolved_hunks,
+            },
+        })
+    }
+
+    /// Generates partially-merged output where resolved hunks are replaced
+    /// with their resolution content and unresolved hunks retain their original
+    /// conflict markers.
+    ///
+    /// This is a **read-only** operation — it does not change session state,
+    /// so the user can continue resolving after a partial save.
+    ///
+    /// Callable from `Parsed`, `Active`, or `FullyResolved` states.
+    ///
+    /// # Errors
+    ///
+    /// Returns `ApplyError::InternalError` if an unresolved hunk is missing
+    /// its `original_text`.
+    pub fn apply_partial(&self) -> Result<PartialApplyResult, ApplyError> {
+        match self.state {
+            MergeState::Parsed | MergeState::Active | MergeState::FullyResolved => {}
+            state => {
+                return Err(ApplyError::InternalError(format!(
+                    "cannot apply partial in state {state:?}"
+                )));
+            }
+        }
+
+        let mut output = String::new();
+        let mut unresolved = Vec::new();
+        let segment_count = self.segments.len();
+
+        for (i, segment) in self.segments.iter().enumerate() {
+            match segment {
+                Segment::Clean(text) => {
+                    output.push_str(text);
+                }
+                Segment::Conflict(hunk_index) => {
+                    let hunk = &self.hunks[*hunk_index];
+                    if let HunkState::Resolved(resolution) = &hunk.state {
+                        output.push_str(&resolution.content);
+                    } else {
+                        // Use original conflict marker text
+                        let original = hunk.original_text.as_ref().ok_or_else(|| {
+                            ApplyError::InternalError(format!(
+                                "hunk {hunk_index} missing original_text for partial apply"
+                            ))
+                        })?;
+                        output.push_str(original);
+                        unresolved.push(hunk.id);
+                    }
+                }
+            }
+            if i < segment_count - 1 {
+                output.push('\n');
+            }
+        }
+
+        let total_hunks = self.hunks.len();
+        let resolved_hunks = total_hunks - unresolved.len();
+
+        Ok(PartialApplyResult {
+            content: output,
+            unresolved_hunks: unresolved,
             summary: MergeSummary {
                 total_hunks,
                 resolved_hunks,
@@ -986,5 +1052,80 @@ after";
             MergeState::Parsed,
             MergeState::Parsed
         ));
+    }
+
+    // --- Partial apply tests ---
+
+    #[test]
+    fn apply_partial_all_resolved() {
+        let mut session = session_with_conflict();
+        let hunk_id = session.hunks()[0].id;
+        let resolution = Resolution::accept_left(&session.hunks()[0]);
+        session.set_resolution(hunk_id, resolution).unwrap();
+
+        let partial = session.apply_partial().unwrap();
+        // Should produce same output as full apply path
+        assert_eq!(partial.content, "before\nleft\nafter");
+        assert!(partial.unresolved_hunks.is_empty());
+        assert_eq!(partial.summary.total_hunks, 1);
+        assert_eq!(partial.summary.resolved_hunks, 1);
+    }
+
+    #[test]
+    fn apply_partial_some_resolved() {
+        let mut session = session_with_multiple_conflicts();
+        let hunk1_id = session.hunks()[0].id;
+        let resolution1 = Resolution::accept_left(&session.hunks()[0]);
+        session.set_resolution(hunk1_id, resolution1).unwrap();
+
+        let partial = session.apply_partial().unwrap();
+        // First hunk resolved, second preserved as markers
+        assert!(partial.content.contains("left1"));
+        assert!(partial.content.contains("<<<<<<<"));
+        assert!(partial.content.contains(">>>>>>>"));
+        assert_eq!(partial.unresolved_hunks.len(), 1);
+        assert_eq!(partial.summary.resolved_hunks, 1);
+        assert_eq!(partial.summary.total_hunks, 2);
+    }
+
+    #[test]
+    fn apply_partial_none_resolved() {
+        let session = session_with_conflict();
+        let partial = session.apply_partial().unwrap();
+        // Output should equal the original input
+        assert!(partial.content.contains("<<<<<<<"));
+        assert!(partial.content.contains(">>>>>>>"));
+        assert_eq!(partial.unresolved_hunks.len(), 1);
+        assert_eq!(partial.summary.resolved_hunks, 0);
+    }
+
+    #[test]
+    fn apply_partial_does_not_change_state() {
+        let mut session = session_with_multiple_conflicts();
+        let hunk1_id = session.hunks()[0].id;
+        let resolution1 = Resolution::accept_left(&session.hunks()[0]);
+        session.set_resolution(hunk1_id, resolution1).unwrap();
+        assert_eq!(session.state(), MergeState::Active);
+
+        let _ = session.apply_partial().unwrap();
+        // State should remain Active
+        assert_eq!(session.state(), MergeState::Active);
+    }
+
+    #[test]
+    fn apply_partial_roundtrip() {
+        let mut session = session_with_multiple_conflicts();
+        let hunk1_id = session.hunks()[0].id;
+        let resolution1 = Resolution::accept_left(&session.hunks()[0]);
+        session.set_resolution(hunk1_id, resolution1).unwrap();
+
+        let partial = session.apply_partial().unwrap();
+
+        // Re-parse the partial output
+        let reparsed =
+            MergeSession::from_conflicted(&partial.content, PathBuf::from("test.rs")).unwrap();
+        // Should have exactly 1 unresolved hunk (the second one)
+        assert_eq!(reparsed.hunks().len(), 1);
+        assert_eq!(reparsed.unresolved_hunks().len(), 1);
     }
 }

--- a/crates/weavr-tui/src/help.rs
+++ b/crates/weavr-tui/src/help.rs
@@ -106,6 +106,14 @@ pub fn build_help_sections(map: &KeybindingMap) -> Vec<HelpSection> {
                     description: "Save and quit",
                 },
                 HelpBinding {
+                    key: ":w!".to_string(),
+                    description: "Save with unresolved hunks (markers preserved)",
+                },
+                HelpBinding {
+                    key: ":wq!".to_string(),
+                    description: "Save with unresolved hunks and quit",
+                },
+                HelpBinding {
                     key: ":q!".to_string(),
                     description: "Force quit",
                 },

--- a/crates/weavr-tui/src/input.rs
+++ b/crates/weavr-tui/src/input.rs
@@ -82,6 +82,10 @@ pub enum Command {
     Quit,
     /// Write and quit (`:wq` or `:x`).
     WriteQuit,
+    /// Write with unresolved hunks, preserving conflict markers (`:w!`).
+    WritePartial,
+    /// Write with unresolved hunks and quit (`:wq!`).
+    WritePartialQuit,
     /// Force quit without saving (`:q!`).
     ForceQuit,
     /// Show help (`:help`).
@@ -110,6 +114,8 @@ impl Command {
             "wa" => Self::WriteAndStage,
             "q" => Self::Quit,
             "wq" | "x" => Self::WriteQuit,
+            "w!" => Self::WritePartial,
+            "wq!" => Self::WritePartialQuit,
             "q!" => Self::ForceQuit,
             "help" => Self::Help,
             "n" | "next" => Self::NextFile,
@@ -138,6 +144,8 @@ impl Command {
     pub fn description(&self) -> &str {
         match self {
             Self::Write => "write",
+            Self::WritePartial => "write (partial)",
+            Self::WritePartialQuit => "write (partial) and quit",
             Self::WriteAndStage => "write and stage",
             Self::Quit => "quit",
             Self::WriteQuit => "write and quit",
@@ -254,6 +262,18 @@ mod tests {
     fn parse_write_quit() {
         assert_eq!(Command::parse("wq"), Command::WriteQuit);
         assert_eq!(Command::parse("x"), Command::WriteQuit);
+    }
+
+    #[test]
+    fn parse_w_bang() {
+        assert_eq!(Command::parse("w!"), Command::WritePartial);
+        assert_eq!(Command::parse("  w!  "), Command::WritePartial);
+    }
+
+    #[test]
+    fn parse_wq_bang() {
+        assert_eq!(Command::parse("wq!"), Command::WritePartialQuit);
+        assert_eq!(Command::parse("  wq!  "), Command::WritePartialQuit);
     }
 
     #[test]

--- a/crates/weavr-tui/src/lib.rs
+++ b/crates/weavr-tui/src/lib.rs
@@ -69,6 +69,7 @@ pub enum FocusedPane {
 }
 
 /// Application state for the TUI.
+#[allow(clippy::struct_excessive_bools)]
 pub struct App {
     /// The active merge session.
     pub(crate) session: Option<MergeSession>,
@@ -121,6 +122,8 @@ pub struct App {
     pub(crate) stage_prompt: bool,
     /// Multi-file workspace (None for single-file mode).
     pub(crate) workspace: Option<workspace::Workspace>,
+    /// Whether a partial write was requested (single-file mode).
+    pub(crate) partial_write: bool,
 }
 
 impl App {
@@ -156,6 +159,7 @@ impl App {
             stage_requested: false,
             stage_prompt: false,
             workspace: None,
+            partial_write: false,
         }
     }
 
@@ -191,6 +195,7 @@ impl App {
             stage_requested: false,
             stage_prompt: false,
             workspace: None,
+            partial_write: false,
         }
     }
 
@@ -440,6 +445,8 @@ impl App {
         let cmd = Command::parse(&self.command_buffer);
         match cmd {
             Command::Write => self.write_file(),
+            Command::WritePartial => self.write_file_partial(),
+            Command::WritePartialQuit => self.write_partial_and_quit(),
             Command::WriteAndStage => self.write_and_stage(),
             Command::Quit => self.try_quit(),
             Command::WriteQuit => self.write_and_quit(),
@@ -503,6 +510,44 @@ impl App {
         }
     }
 
+    /// Writes the file with unresolved hunks preserved as conflict markers (`:w!`).
+    fn write_file_partial(&mut self) {
+        if !self.has_unresolved_hunks() {
+            // No unresolved hunks — delegate to normal write
+            self.write_file();
+            return;
+        }
+        let count = self.unresolved_count();
+        if self.is_multi_file() {
+            if let Some(ref mut ws) = self.workspace {
+                ws.current_mut().written = true;
+                ws.current_mut().partial = true;
+            }
+            self.set_status_message(&format!("Saved with {count} unresolved hunks remaining"));
+        } else {
+            self.partial_write = true;
+            self.quit();
+        }
+    }
+
+    /// Writes the file with unresolved hunks and quits/advances (`:wq!`).
+    fn write_partial_and_quit(&mut self) {
+        if !self.has_unresolved_hunks() {
+            // No unresolved hunks — delegate to normal write-quit
+            self.write_and_quit();
+            return;
+        }
+        if self.is_multi_file() {
+            if let Some(ref mut ws) = self.workspace {
+                ws.current_mut().partial = true;
+            }
+            self.complete_current_and_advance();
+        } else {
+            self.partial_write = true;
+            self.quit();
+        }
+    }
+
     /// Attempts to quit, showing a warning if there are unresolved hunks.
     fn try_quit(&mut self) {
         if self.is_multi_file() {
@@ -556,6 +601,12 @@ impl App {
     #[must_use]
     pub fn stage_requested(&self) -> bool {
         self.stage_requested
+    }
+
+    /// Returns whether a partial write was requested.
+    #[must_use]
+    pub fn partial_write_requested(&self) -> bool {
+        self.partial_write
     }
 
     /// Sets whether to show the staging prompt on `:wq`.

--- a/crates/weavr-tui/src/workspace.rs
+++ b/crates/weavr-tui/src/workspace.rs
@@ -41,6 +41,8 @@ pub struct FileState {
     pub focused_pane: FocusedPane,
     /// Whether the file has been marked as saved/completed.
     pub written: bool,
+    /// Whether the file was saved with unresolved hunks (partial write).
+    pub partial: bool,
 }
 
 impl FileState {
@@ -57,6 +59,7 @@ impl FileState {
             stage_requested: false,
             focused_pane: FocusedPane::default(),
             written: false,
+            partial: false,
         }
     }
 


### PR DESCRIPTION
## Summary

- Add `:w!` and `:wq!` TUI commands to save files with unresolved hunks, preserving original conflict markers with perfect round-trip fidelity
- Store verbatim conflict marker text (`original_text`) during parsing across all three parsers (Git, jj snapshot, jj diff)
- Add `apply_partial()` method to `MergeSession` — a read-only operation that replaces resolved hunks while preserving unresolved markers
- Partial saves skip auto-staging (files still have conflict markers) and set appropriate exit codes

Closes #80

## Test plan

- [x] `cargo build --workspace`
- [x] `cargo test --workspace` (223 weavr-core tests pass, 11 new tests added)
- [x] `cargo clippy --workspace --all-targets -- -D warnings`
- [x] `cargo fmt --all --check`
- [ ] Manual: create file with 3 conflict hunks, resolve 1, `:w!` to save, verify output has 1 resolved region and 2 original marker blocks
- [ ] Manual: verify `:wq!` quits/advances in multi-file mode