### PR TITLE
Register weavr as a jj merge tool in weavr init

### DIFF
--- a/crates/weavr-cli/src/cli.rs
+++ b/crates/weavr-cli/src/cli.rs
@@ -80,7 +80,7 @@ pub struct InitArgs {
 pub struct MergeDriverArgs {
     /// Base (ancestor) version (%O)
     pub base: PathBuf,
-    /// Current (ours) version (%A) — result is written here
+    /// Current (ours) version (%A) — result is written here unless --output is set
     pub ours: PathBuf,
     /// Other (theirs) version (%B)
     pub theirs: PathBuf,

--- a/crates/weavr-cli/src/init.rs
+++ b/crates/weavr-cli/src/init.rs
@@ -82,18 +82,21 @@ pub fn run(args: &InitArgs) -> Result<i32, CliError> {
     let mut actions = Actions::new();
 
     // Resolve repo root: try git first (unless --no-git), then jj (unless --no-jj), then cwd.
-    let repo_root = if args.no_git {
-        fallback_repo_root(args)?
+    let git_root = if args.no_git {
+        None
     } else {
-        match git_repo_root() {
-            Ok(root) => root,
-            Err(_) => fallback_repo_root(args)?,
-        }
+        git_repo_root().ok()
+    };
+
+    let repo_root = if let Some(ref root) = git_root {
+        root.clone()
+    } else {
+        fallback_repo_root(args)?
     };
 
     write_config_file(&repo_root, args.force, &mut actions)?;
 
-    if !args.no_git && git_repo_root().is_ok() {
+    if git_root.is_some() {
         setup_git_merge_driver(args.global, &mut actions)?;
         setup_gitattributes(&repo_root, &args.patterns, &mut actions)?;
     }
@@ -139,8 +142,7 @@ pub fn run(args: &InitArgs) -> Result<i32, CliError> {
 /// Fallback repo root resolution when git is unavailable or skipped.
 fn fallback_repo_root(args: &InitArgs) -> Result<PathBuf, CliError> {
     #[cfg(feature = "jj")]
-    {
-        let _ = args;
+    if !args.no_jj {
         if let Ok(root) = jj_repo_root() {
             return Ok(root);
         }
@@ -300,6 +302,11 @@ fn jj_repo_root() -> Result<PathBuf, CliError> {
 }
 
 /// Reads the effective jj config value, returning `None` if not set.
+///
+/// Note: `jj config get` reads across all scopes (repo, user, default) and
+/// returns the effective value. There is no `--repo`/`--user` flag for `get`,
+/// so the idempotency check in `setup_jj_merge_tool` uses the effective value
+/// rather than a scope-specific one.
 #[cfg(feature = "jj")]
 fn jj_config_get(key: &str) -> Option<String> {
     let output = std::process::Command::new("jj")

--- a/crates/weavr-cli/src/merge_driver.rs
+++ b/crates/weavr-cli/src/merge_driver.rs
@@ -89,7 +89,7 @@ fn resolve_strategy(cli_strategy: Option<Strategy>, config: &WeavrConfig) -> Str
 /// Parses conflicted content, applies the strategy, and writes the result.
 fn resolve_conflicts(
     content: &str,
-    ours_path: &Path,
+    dest_path: &Path,
     file_path: &Path,
     strategy: Strategy,
     deduplicate: bool,
@@ -101,7 +101,7 @@ fn resolve_conflicts(
 
     if hunks.is_empty() {
         // No conflict markers found — write as-is
-        std::fs::write(ours_path, content)?;
+        std::fs::write(dest_path, content)?;
         return Ok(0);
     }
 
@@ -130,7 +130,7 @@ fn resolve_conflicts(
     session.validate()?;
     let result = session.complete()?;
 
-    std::fs::write(ours_path, &result.content)?;
+    std::fs::write(dest_path, &result.content)?;
     Ok(0)
 }
 

--- a/crates/weavr-cli/tests/init_command.rs
+++ b/crates/weavr-cli/tests/init_command.rs
@@ -15,6 +15,7 @@ fn init_git_repo(dir: &TempDir) {
         .expect("failed to init git repo");
 }
 
+#[cfg(feature = "jj")]
 fn jj_available() -> bool {
     std::process::Command::new("jj")
         .arg("version")
@@ -22,6 +23,7 @@ fn jj_available() -> bool {
         .is_ok_and(|o| o.status.success())
 }
 
+#[cfg(feature = "jj")]
 fn init_jj_repo(dir: &TempDir) {
     std::process::Command::new("jj")
         .args(["git", "init"])
@@ -135,6 +137,7 @@ fn init_no_git_skips_driver() {
     assert!(!dir.path().join(".gitattributes").exists());
 }
 
+#[cfg(feature = "jj")]
 #[test]
 fn init_no_jj_skips_jj_setup() {
     let dir = TempDir::new().unwrap();
@@ -147,16 +150,18 @@ fn init_no_jj_skips_jj_setup() {
         .success()
         .stdout(predicates::str::contains("created .weavr.toml"));
 
-    // Should not mention jj in output
+    // Second run should succeed and not mention jj in output
     let output = weavr_cmd()
         .args(["init", "--no-jj"])
         .current_dir(dir.path())
         .output()
         .unwrap();
+    assert!(output.status.success());
     let stdout = String::from_utf8(output.stdout).unwrap();
     assert!(!stdout.contains("jj merge tool"));
 }
 
+#[cfg(feature = "jj")]
 #[test]
 fn init_in_jj_repo_configures_merge_tool() {
     if !jj_available() {
@@ -186,6 +191,7 @@ fn init_in_jj_repo_configures_merge_tool() {
     assert_eq!(value.trim(), "weavr");
 }
 
+#[cfg(feature = "jj")]
 #[test]
 fn init_in_colocated_repo_configures_both() {
     if !jj_available() {
@@ -206,6 +212,7 @@ fn init_in_colocated_repo_configures_both() {
         .stdout(predicates::str::contains("configured jj merge tool"));
 }
 
+#[cfg(feature = "jj")]
 #[test]
 fn init_jj_idempotent() {
     if !jj_available() {
@@ -233,6 +240,7 @@ fn init_jj_idempotent() {
         .stdout(predicates::str::contains("nothing to do"));
 }
 
+#[cfg(feature = "jj")]
 #[test]
 fn init_jj_scope_user() {
     if !jj_available() {

--- a/crates/weavr-cli/tests/merge_driver.rs
+++ b/crates/weavr-cli/tests/merge_driver.rs
@@ -164,6 +164,40 @@ fn merge_driver_output_flag_writes_to_separate_file() {
 }
 
 #[test]
+fn merge_driver_output_flag_with_conflict() {
+    let base = temp_file("line1\ncommon\nline3\n");
+    let ours = temp_file("line1\nours-change\nline3\n");
+    let theirs = temp_file("line1\ntheirs-change\nline3\n");
+
+    let output_file = tempfile::NamedTempFile::new().unwrap();
+
+    weavr_cmd()
+        .args([
+            "merge-driver",
+            base.path().to_str().unwrap(),
+            ours.path().to_str().unwrap(),
+            theirs.path().to_str().unwrap(),
+            "7",
+            "test.txt",
+            "--strategy=left",
+            "--output",
+            output_file.path().to_str().unwrap(),
+        ])
+        .assert()
+        .success();
+
+    // Result written to output file with resolved content
+    let result = std::fs::read_to_string(output_file.path()).unwrap();
+    assert!(result.contains("ours-change"));
+    assert!(!result.contains("theirs-change"));
+    assert!(!result.contains("<<<<<<<"));
+
+    // Ours should be untouched
+    let ours_content = std::fs::read_to_string(ours.path()).unwrap();
+    assert_eq!(ours_content, "line1\nours-change\nline3\n");
+}
+
+#[test]
 fn bare_weavr_still_works() {
     // Ensure `weavr` with no subcommand still parses successfully.
     // It may exit 0 ("No conflicted files found") or non-zero depending


### PR DESCRIPTION
## Summary

Closes #105

- Add `--output <path>` flag to `merge-driver` so jj's merge tool protocol can write results to a separate `$output` file instead of overwriting ours
- Add `JjScope` enum, `--no-jj`, and `--jj-scope` flags to `weavr init` (all `#[cfg(feature = "jj")]`)
- Extend `init.rs` with `jj_repo_root()`, `jj_config_get()`, and `setup_jj_merge_tool()` to auto-detect and configure jj repos
- Repo root resolution now tries git → jj → cwd; colocated repos get both Git and jj configured automatically
- Idempotent: second run reports "nothing to do" when config already matches

## Test plan

- [x] `cargo test --workspace` — all 665 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all --check` — clean
- [x] Integration tests: jj repo init, colocated repo, idempotency, user scope, `--no-jj` skip, `--output` flag
- [ ] Manual: run `weavr init` in a jj repo and verify `jj config get merge-tools.weavr.program` returns `weavr`