### PR TITLE
Remove stale dead_code allow on AmbiguousHunks (#127)

### DIFF
--- a/crates/weavr-cli/src/error.rs
+++ b/crates/weavr-cli/src/error.rs
@@ -51,7 +51,6 @@ pub enum CliError {
     Config(#[from] crate::config::ConfigError),
 
     #[error("Ambiguous hunks remain: {0} hunks could not be auto-resolved")]
-    #[allow(dead_code)] // Reserved for --fail-on-ambiguous implementation
     AmbiguousHunks(usize),
 
     #[error("Merge driver error: {0}")]


### PR DESCRIPTION
## Summary
- Removes `#[allow(dead_code)]` and "Reserved for --fail-on-ambiguous implementation" comment from `CliError::AmbiguousHunks`
- The variant is actively used in both `resolve.rs` and `headless.rs` — the allow was stale

Closes #127