### PR TITLE
Extract shared try_merge scaffold for AST mergers (#130)

### DIFF
--- a/crates/weavr-ast/src/mergers/common.rs
+++ b/crates/weavr-ast/src/mergers/common.rs
@@ -1,6 +1,60 @@
-//! Shared set-merging logic used by all language-specific mergers.
+//! Shared logic used by all language-specific mergers.
 
 use std::collections::BTreeSet;
+
+use weavr_core::ConflictHunk;
+
+use crate::error::AstError;
+use crate::AstMergeResult;
+
+/// The result of a language-specific merge, generic over the parsed item type.
+pub(crate) struct RawMergeOutput<D> {
+    pub items: Vec<D>,
+    pub confidence: f32,
+    pub description: String,
+}
+
+/// Shared try_merge scaffold for all AST mergers.
+///
+/// Handles the common parse-dispatch-format control flow:
+/// 1. Parse left and right fragments (bail if unparsable).
+/// 2. Parse the optional base fragment.
+/// 3. Dispatch to two-way or three-way merge.
+/// 4. Format the merged items into a string.
+/// 5. Return an [`AstMergeResult`].
+pub(crate) fn try_merge_ast<D>(
+    hunk: &ConflictHunk,
+    parse: impl Fn(&str) -> Option<Vec<D>>,
+    merge_two_way: impl FnOnce(&[D], &[D]) -> Result<Option<RawMergeOutput<D>>, AstError>,
+    merge_three_way: impl FnOnce(&[D], &[D], &[D]) -> Result<Option<RawMergeOutput<D>>, AstError>,
+    format: impl FnOnce(&[D]) -> Result<String, AstError>,
+) -> Result<Option<AstMergeResult>, AstError> {
+    let Some(left) = parse(&hunk.left.text) else {
+        return Ok(None);
+    };
+    let Some(right) = parse(&hunk.right.text) else {
+        return Ok(None);
+    };
+    let base = hunk.base.as_ref().and_then(|b| parse(&b.text));
+
+    let merged = if let Some(ref base_items) = base {
+        merge_three_way(base_items, &left, &right)?
+    } else {
+        merge_two_way(&left, &right)?
+    };
+
+    let Some(result) = merged else {
+        return Ok(None);
+    };
+
+    let content = format(&result.items)?;
+
+    Ok(Some(AstMergeResult {
+        content,
+        confidence: result.confidence,
+        description: result.description,
+    }))
+}
 
 /// Three-way merge for ordered sets: union of both sides' additions,
 /// minus elements deleted by either side (that weren't re-added by the other).

--- a/crates/weavr-ast/src/mergers/csharp_merger/member_merge.rs
+++ b/crates/weavr-ast/src/mergers/csharp_merger/member_merge.rs
@@ -8,14 +8,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::identity::{CSharpIdentity, MemberIdentity};
 use super::parse::{is_complex_using, to_member_identity, CSharpDeclaration, DeclarationKind};
 use super::using_merge;
+use crate::error::AstError;
+use crate::mergers::common::RawMergeOutput;
 use crate::mergers::confidence::{compute_import_confidence, compute_mixed_confidence};
-
-/// The result of merging declarations from two or three sides.
-pub(super) struct MergedDeclarations {
-    pub declarations: Vec<CSharpDeclaration>,
-    pub confidence: f32,
-    pub description: String,
-}
 
 /// Returns whether all declarations are using directives.
 fn all_usings(decls: &[CSharpDeclaration]) -> bool {
@@ -53,16 +48,18 @@ fn normalize_whitespace(s: &str) -> String {
 pub(super) fn merge_two_way(
     left: &[CSharpDeclaration],
     right: &[CSharpDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<CSharpDeclaration>>, AstError> {
     // Special-case: pure using-directive merge
     if all_usings(left) && all_usings(right) {
-        return using_merge::merge_using_directives(left, right, None).map(|(decls, desc)| {
-            MergedDeclarations {
-                confidence: compute_import_confidence(all_usings(&decls), false),
-                declarations: decls,
-                description: desc,
-            }
-        });
+        return Ok(
+            using_merge::merge_using_directives(left, right, None).map(|(decls, desc)| {
+                RawMergeOutput {
+                    confidence: compute_import_confidence(all_usings(&decls), false),
+                    items: decls,
+                    description: desc,
+                }
+            }),
+        );
     }
 
     let right_map = build_identity_map(right);
@@ -96,7 +93,7 @@ pub(super) fn merge_two_way(
             || right_usings.iter().any(is_complex_using)
         {
             // Complex usings cannot be safely merged -- bail out to text merge
-            return None;
+            return Ok(None);
         } else {
             // Identical usings -- just keep left's
             merged.extend(left_usings);
@@ -129,7 +126,7 @@ pub(super) fn merge_two_way(
                         has_member_disjoint = true;
                         merged.push(merged_decl);
                     }
-                    None => return None, // Unresolvable conflict
+                    None => return Ok(None), // Unresolvable conflict
                 }
             }
         } else {
@@ -156,11 +153,11 @@ pub(super) fn merge_two_way(
     };
 
     let confidence = compute_mixed_confidence(has_using_merge, has_member_disjoint, false);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 /// Three-way merge: classifies each identity as unchanged/added/modified/deleted per side.
@@ -169,15 +166,17 @@ pub(super) fn merge_three_way(
     base: &[CSharpDeclaration],
     left: &[CSharpDeclaration],
     right: &[CSharpDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<CSharpDeclaration>>, AstError> {
     // Special-case: pure using-directive merge
     if all_usings(left) && all_usings(right) && all_usings(base) {
-        return using_merge::merge_using_directives(left, right, Some(base)).map(
-            |(decls, desc)| MergedDeclarations {
-                confidence: compute_import_confidence(all_usings(&decls), true),
-                declarations: decls,
-                description: desc,
-            },
+        return Ok(
+            using_merge::merge_using_directives(left, right, Some(base)).map(|(decls, desc)| {
+                RawMergeOutput {
+                    confidence: compute_import_confidence(all_usings(&decls), true),
+                    items: decls,
+                    description: desc,
+                }
+            }),
         );
     }
 
@@ -220,7 +219,7 @@ pub(super) fn merge_three_way(
             || right_usings.iter().any(is_complex_using)
         {
             // Complex usings cannot be safely merged -- bail out to text merge
-            return None;
+            return Ok(None);
         } else {
             merged.extend(left_usings);
         }
@@ -253,18 +252,18 @@ pub(super) fn merge_three_way(
             // In all three -- check for modifications
             (Some(b), Some(l), Some(r)) => {
                 if !merge_three_present(b, l, r, &mut merged, &mut has_member_disjoint) {
-                    return None;
+                    return Ok(None);
                 }
             }
             // Deleted by one side -- respect deletion (unless modified by the other)
             (Some(b), Some(l), None) => {
                 if !source_equal(b, l) {
-                    return None;
+                    return Ok(None);
                 }
             }
             (Some(b), None, Some(r)) => {
                 if !source_equal(b, r) {
-                    return None;
+                    return Ok(None);
                 }
             }
             // Both sides deleted, or identity not actually present
@@ -279,7 +278,7 @@ pub(super) fn merge_three_way(
                             has_member_disjoint = true;
                             merged.push(merged_decl);
                         }
-                        None => return None,
+                        None => return Ok(None),
                     }
                 }
             }
@@ -299,11 +298,11 @@ pub(super) fn merge_three_way(
     };
 
     let confidence = compute_mixed_confidence(has_using_merge, has_member_disjoint, true);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 /// Handles the case where a declaration is present in all three sides (base, left, right).
@@ -549,23 +548,23 @@ mod tests {
     fn two_way_disjoint_classes() {
         let left = parse("class Foo { }");
         let right = parse("class Bar { }");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 2);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 2);
     }
 
     #[test]
     fn two_way_identical_classes() {
         let left = parse("class Foo { }");
         let right = parse("class Foo { }");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 1);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 1);
     }
 
     #[test]
     fn two_way_conflicting_classes() {
         let left = parse("class Foo { public void A() { } }");
         let right = parse("class Foo { public void B() { } }");
-        let result = merge_two_way(&left, &right);
+        let result = merge_two_way(&left, &right).unwrap();
         assert!(result.is_some());
     }
 

--- a/crates/weavr-ast/src/mergers/csharp_merger/mod.rs
+++ b/crates/weavr-ast/src/mergers/csharp_merger/mod.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use weavr_core::{ConflictHunk, Language};
 
 use crate::error::AstError;
+use crate::mergers::common::try_merge_ast;
 use crate::{AstMergeResult, AstMerger};
 
 use self::format::format_declarations;
@@ -49,41 +50,15 @@ impl AstMerger for CSharpMerger {
     }
 
     fn try_merge(&self, hunk: &ConflictHunk) -> Result<Option<AstMergeResult>, AstError> {
-        let left = match parse_fragment(&hunk.left.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let right = match parse_fragment(&hunk.right.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let base = if let Some(ref base_content) = hunk.base {
-            match parse_fragment(&base_content.text) {
+        try_merge_ast(
+            hunk,
+            |text| match parse_fragment(text) {
                 ParsedFragment::Declarations(decls) => Some(decls),
                 ParsedFragment::Unparsable => None,
-            }
-        } else {
-            None
-        };
-
-        let result = if let Some(base_decls) = base {
-            merge_three_way(&base_decls, &left, &right)
-        } else {
-            merge_two_way(&left, &right)
-        };
-
-        let Some(result) = result else {
-            return Ok(None);
-        };
-
-        let content = format_declarations(&result.declarations);
-
-        Ok(Some(AstMergeResult {
-            content,
-            confidence: result.confidence,
-            description: result.description,
-        }))
+            },
+            |left, right| merge_two_way(left, right),
+            |base, left, right| merge_three_way(base, left, right),
+            |decls| Ok(format_declarations(decls)),
+        )
     }
 }

--- a/crates/weavr-ast/src/mergers/go_merger/member_merge.rs
+++ b/crates/weavr-ast/src/mergers/go_merger/member_merge.rs
@@ -8,14 +8,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::identity::GoIdentity;
 use super::import_merge;
 use super::parse::{is_dot_import, DeclarationKind, GoDeclaration};
+use crate::error::AstError;
+use crate::mergers::common::RawMergeOutput;
 use crate::mergers::confidence::{compute_import_confidence, compute_mixed_confidence};
-
-/// The result of merging declarations from two or three sides.
-pub(super) struct MergedDeclarations {
-    pub declarations: Vec<GoDeclaration>,
-    pub confidence: f32,
-    pub description: String,
-}
 
 /// Returns whether all declarations are import declarations.
 fn all_imports(decls: &[GoDeclaration]) -> bool {
@@ -53,16 +48,18 @@ fn normalize_whitespace(s: &str) -> String {
 pub(super) fn merge_two_way(
     left: &[GoDeclaration],
     right: &[GoDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<GoDeclaration>>, AstError> {
     // Special-case: pure import merge
     if all_imports(left) && all_imports(right) {
-        return import_merge::merge_import_declarations(left, right, None).map(|(decls, desc)| {
-            MergedDeclarations {
-                confidence: compute_import_confidence(all_imports(&decls), false),
-                declarations: decls,
-                description: desc,
-            }
-        });
+        return Ok(
+            import_merge::merge_import_declarations(left, right, None).map(|(decls, desc)| {
+                RawMergeOutput {
+                    confidence: compute_import_confidence(all_imports(&decls), false),
+                    items: decls,
+                    description: desc,
+                }
+            }),
+        );
     }
 
     let right_map = build_identity_map(right);
@@ -95,7 +92,7 @@ pub(super) fn merge_two_way(
         } else if left_imports.iter().any(is_dot_import) || right_imports.iter().any(is_dot_import)
         {
             // Dot imports cannot be safely merged -- bail out to text merge
-            return None;
+            return Ok(None);
         } else {
             // Identical imports -- just keep left's
             merged.extend(left_imports);
@@ -128,7 +125,7 @@ pub(super) fn merge_two_way(
                         has_member_disjoint = true;
                         merged.push(merged_decl);
                     }
-                    None => return None, // Unresolvable conflict
+                    None => return Ok(None), // Unresolvable conflict
                 }
             }
         } else {
@@ -155,11 +152,11 @@ pub(super) fn merge_two_way(
     };
 
     let confidence = compute_mixed_confidence(has_import_merge, has_member_disjoint, false);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 /// Three-way merge: classifies each identity as unchanged/added/modified/deleted per side.
@@ -168,15 +165,17 @@ pub(super) fn merge_three_way(
     base: &[GoDeclaration],
     left: &[GoDeclaration],
     right: &[GoDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<GoDeclaration>>, AstError> {
     // Special-case: pure import merge
     if all_imports(left) && all_imports(right) && all_imports(base) {
-        return import_merge::merge_import_declarations(left, right, Some(base)).map(
-            |(decls, desc)| MergedDeclarations {
-                confidence: compute_import_confidence(all_imports(&decls), true),
-                declarations: decls,
-                description: desc,
-            },
+        return Ok(
+            import_merge::merge_import_declarations(left, right, Some(base)).map(
+                |(decls, desc)| RawMergeOutput {
+                    confidence: compute_import_confidence(all_imports(&decls), true),
+                    items: decls,
+                    description: desc,
+                },
+            ),
         );
     }
 
@@ -221,7 +220,7 @@ pub(super) fn merge_three_way(
             || right_imports.iter().any(is_dot_import)
         {
             // Dot imports cannot be safely merged -- bail out to text merge
-            return None;
+            return Ok(None);
         } else {
             merged.extend(left_imports);
         }
@@ -254,18 +253,18 @@ pub(super) fn merge_three_way(
             // In all three -- check for modifications
             (Some(b), Some(l), Some(r)) => {
                 if !merge_three_present(b, l, r, &mut merged, &mut has_member_disjoint) {
-                    return None;
+                    return Ok(None);
                 }
             }
             // Deleted by one side -- respect deletion (unless modified by the other)
             (Some(b), Some(l), None) => {
                 if !source_equal(b, l) {
-                    return None;
+                    return Ok(None);
                 }
             }
             (Some(b), None, Some(r)) => {
                 if !source_equal(b, r) {
-                    return None;
+                    return Ok(None);
                 }
             }
             // Both sides deleted, or identity not actually present
@@ -280,7 +279,7 @@ pub(super) fn merge_three_way(
                             has_member_disjoint = true;
                             merged.push(merged_decl);
                         }
-                        None => return None,
+                        None => return Ok(None),
                     }
                 }
             }
@@ -300,11 +299,11 @@ pub(super) fn merge_three_way(
     };
 
     let confidence = compute_mixed_confidence(has_import_merge, has_member_disjoint, true);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 /// Handles the case where a declaration is present in all three sides (base, left, right).
@@ -487,23 +486,23 @@ mod tests {
     fn two_way_disjoint_functions() {
         let left = parse("func Foo() {}");
         let right = parse("func Bar() {}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 2);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 2);
     }
 
     #[test]
     fn two_way_identical_functions() {
         let left = parse("func Foo() {}");
         let right = parse("func Foo() {}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 1);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 1);
     }
 
     #[test]
     fn two_way_conflicting_functions() {
         let left = parse("func Foo() { return 1 }");
         let right = parse("func Foo() { return 2 }");
-        let result = merge_two_way(&left, &right);
+        let result = merge_two_way(&left, &right).unwrap();
         assert!(result.is_none(), "conflicting functions should return None");
     }
 
@@ -528,19 +527,19 @@ mod tests {
     fn struct_disjoint_field_additions() {
         let left = parse("type Config struct {\n\tName string\n\tHost string\n}");
         let right = parse("type Config struct {\n\tName string\n\tPort int\n}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 1);
-        assert!(result.declarations[0].source_text.contains("Host"));
-        assert!(result.declarations[0].source_text.contains("Port"));
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 1);
+        assert!(result.items[0].source_text.contains("Host"));
+        assert!(result.items[0].source_text.contains("Port"));
     }
 
     #[test]
     fn interface_disjoint_method_additions() {
         let left = parse("type Handler interface {\n\tServeHTTP()\n\tInit()\n}");
         let right = parse("type Handler interface {\n\tServeHTTP()\n\tClose()\n}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 1);
-        assert!(result.declarations[0].source_text.contains("Init"));
-        assert!(result.declarations[0].source_text.contains("Close"));
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 1);
+        assert!(result.items[0].source_text.contains("Init"));
+        assert!(result.items[0].source_text.contains("Close"));
     }
 }

--- a/crates/weavr-ast/src/mergers/go_merger/mod.rs
+++ b/crates/weavr-ast/src/mergers/go_merger/mod.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use weavr_core::{ConflictHunk, Language};
 
 use crate::error::AstError;
+use crate::mergers::common::try_merge_ast;
 use crate::{AstMergeResult, AstMerger};
 
 use self::format::format_declarations;
@@ -49,41 +50,15 @@ impl AstMerger for GoMerger {
     }
 
     fn try_merge(&self, hunk: &ConflictHunk) -> Result<Option<AstMergeResult>, AstError> {
-        let left = match parse_fragment(&hunk.left.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let right = match parse_fragment(&hunk.right.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let base = if let Some(ref base_content) = hunk.base {
-            match parse_fragment(&base_content.text) {
+        try_merge_ast(
+            hunk,
+            |text| match parse_fragment(text) {
                 ParsedFragment::Declarations(decls) => Some(decls),
                 ParsedFragment::Unparsable => None,
-            }
-        } else {
-            None
-        };
-
-        let result = if let Some(base_decls) = base {
-            merge_three_way(&base_decls, &left, &right)
-        } else {
-            merge_two_way(&left, &right)
-        };
-
-        let Some(result) = result else {
-            return Ok(None);
-        };
-
-        let content = format_declarations(&result.declarations);
-
-        Ok(Some(AstMergeResult {
-            content,
-            confidence: result.confidence,
-            description: result.description,
-        }))
+            },
+            |left, right| merge_two_way(left, right),
+            |base, left, right| merge_three_way(base, left, right),
+            |decls| Ok(format_declarations(decls)),
+        )
     }
 }

--- a/crates/weavr-ast/src/mergers/rust_merger/item_merge.rs
+++ b/crates/weavr-ast/src/mergers/rust_merger/item_merge.rs
@@ -8,15 +8,9 @@ use super::identity::ItemIdentity;
 use super::impl_merge;
 use super::tokens::{build_identity_map, tokens_equal};
 use super::use_merge;
+use crate::mergers::common::RawMergeOutput;
 use crate::mergers::confidence::{compute_import_confidence, compute_mixed_confidence};
 use crate::AstError;
-
-/// The result of merging items from two or three sides.
-pub(super) struct MergedItems {
-    pub items: Vec<Item>,
-    pub confidence: f32,
-    pub description: String,
-}
 
 /// Returns whether all items in the slice are `use` statements.
 fn all_uses(items: &[Item]) -> bool {
@@ -32,11 +26,11 @@ fn all_uses(items: &[Item]) -> bool {
 pub(super) fn merge_two_way(
     left: &[Item],
     right: &[Item],
-) -> Result<Option<MergedItems>, AstError> {
+) -> Result<Option<RawMergeOutput<Item>>, AstError> {
     // Special-case: pure use-statement merge
     if all_uses(left) && all_uses(right) {
         return match use_merge::merge_use_items(left, right, None)? {
-            Some((items, desc)) => Ok(Some(MergedItems {
+            Some((items, desc)) => Ok(Some(RawMergeOutput {
                 confidence: compute_import_confidence(all_uses(&items), false),
                 items,
                 description: desc,
@@ -133,7 +127,7 @@ pub(super) fn merge_two_way(
     };
 
     let confidence = compute_mixed_confidence(has_use_merge, has_impl_disjoint, false);
-    Ok(Some(MergedItems {
+    Ok(Some(RawMergeOutput {
         items: merged,
         confidence,
         description,
@@ -146,11 +140,11 @@ pub(super) fn merge_three_way(
     base: &[Item],
     left: &[Item],
     right: &[Item],
-) -> Result<Option<MergedItems>, AstError> {
+) -> Result<Option<RawMergeOutput<Item>>, AstError> {
     // Special-case: pure use-statement merge
     if all_uses(left) && all_uses(right) && all_uses(base) {
         return match use_merge::merge_use_items(left, right, Some(base))? {
-            Some((items, desc)) => Ok(Some(MergedItems {
+            Some((items, desc)) => Ok(Some(RawMergeOutput {
                 confidence: compute_import_confidence(all_uses(&items), true),
                 items,
                 description: desc,
@@ -275,7 +269,7 @@ pub(super) fn merge_three_way(
     };
 
     let confidence = compute_mixed_confidence(has_use_merge, has_impl_disjoint, true);
-    Ok(Some(MergedItems {
+    Ok(Some(RawMergeOutput {
         items: merged,
         confidence,
         description,

--- a/crates/weavr-ast/src/mergers/rust_merger/mod.rs
+++ b/crates/weavr-ast/src/mergers/rust_merger/mod.rs
@@ -20,6 +20,7 @@ use std::path::Path;
 use weavr_core::{ConflictHunk, Language};
 
 use crate::error::AstError;
+use crate::mergers::common::try_merge_ast;
 use crate::{AstMergeResult, AstMerger};
 
 use self::format::format_items;
@@ -51,41 +52,15 @@ impl AstMerger for RustMerger {
     }
 
     fn try_merge(&self, hunk: &ConflictHunk) -> Result<Option<AstMergeResult>, AstError> {
-        let left = match parse_fragment(&hunk.left.text) {
-            ParsedFragment::Items(items) => items,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let right = match parse_fragment(&hunk.right.text) {
-            ParsedFragment::Items(items) => items,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let base = if let Some(ref base_content) = hunk.base {
-            match parse_fragment(&base_content.text) {
+        try_merge_ast(
+            hunk,
+            |text| match parse_fragment(text) {
                 ParsedFragment::Items(items) => Some(items),
                 ParsedFragment::Unparsable => None,
-            }
-        } else {
-            None
-        };
-
-        let merged = if let Some(base_items) = base {
-            merge_three_way(&base_items, &left, &right)?
-        } else {
-            merge_two_way(&left, &right)?
-        };
-
-        let Some(result) = merged else {
-            return Ok(None);
-        };
-
-        let content = format_items(&result.items)?;
-
-        Ok(Some(AstMergeResult {
-            content,
-            confidence: result.confidence,
-            description: result.description,
-        }))
+            },
+            |left, right| merge_two_way(left, right),
+            |base, left, right| merge_three_way(base, left, right),
+            |items| format_items(items),
+        )
     }
 }

--- a/crates/weavr-ast/src/mergers/typescript_merger/member_merge.rs
+++ b/crates/weavr-ast/src/mergers/typescript_merger/member_merge.rs
@@ -8,14 +8,9 @@ use std::collections::{BTreeMap, BTreeSet};
 use super::identity::TsIdentity;
 use super::import_merge;
 use super::parse::{DeclarationKind, TsDeclaration};
+use crate::error::AstError;
+use crate::mergers::common::RawMergeOutput;
 use crate::mergers::confidence::{compute_import_confidence, compute_mixed_confidence};
-
-/// The result of merging declarations from two or three sides.
-pub(super) struct MergedDeclarations {
-    pub declarations: Vec<TsDeclaration>,
-    pub confidence: f32,
-    pub description: String,
-}
 
 /// Returns whether all declarations are import statements.
 fn all_imports(decls: &[TsDeclaration]) -> bool {
@@ -53,16 +48,18 @@ fn normalize_whitespace(s: &str) -> String {
 pub(super) fn merge_two_way(
     left: &[TsDeclaration],
     right: &[TsDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<TsDeclaration>>, AstError> {
     // Special-case: pure import merge
     if all_imports(left) && all_imports(right) {
-        return import_merge::merge_import_declarations(left, right, None).map(|(decls, desc)| {
-            MergedDeclarations {
-                confidence: compute_import_confidence(all_imports(&decls), false),
-                declarations: decls,
-                description: desc,
-            }
-        });
+        return Ok(
+            import_merge::merge_import_declarations(left, right, None).map(|(decls, desc)| {
+                RawMergeOutput {
+                    confidence: compute_import_confidence(all_imports(&decls), false),
+                    items: decls,
+                    description: desc,
+                }
+            }),
+        );
     }
 
     let right_map = build_identity_map(right);
@@ -117,7 +114,7 @@ pub(super) fn merge_two_way(
                 merged.push(decl.clone());
             } else {
                 // Non-import conflict -- bail out (no structural member merging for prototype)
-                return None;
+                return Ok(None);
             }
         } else {
             // Only on left side
@@ -143,11 +140,11 @@ pub(super) fn merge_two_way(
     };
 
     let confidence = compute_mixed_confidence(has_import_merge, false, false);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 /// Three-way merge: classifies each identity as unchanged/added/modified/deleted per side.
@@ -156,15 +153,17 @@ pub(super) fn merge_three_way(
     base: &[TsDeclaration],
     left: &[TsDeclaration],
     right: &[TsDeclaration],
-) -> Option<MergedDeclarations> {
+) -> Result<Option<RawMergeOutput<TsDeclaration>>, AstError> {
     // Special-case: pure import merge
     if all_imports(left) && all_imports(right) && all_imports(base) {
-        return import_merge::merge_import_declarations(left, right, Some(base)).map(
-            |(decls, desc)| MergedDeclarations {
-                confidence: compute_import_confidence(all_imports(&decls), true),
-                declarations: decls,
-                description: desc,
-            },
+        return Ok(
+            import_merge::merge_import_declarations(left, right, Some(base)).map(
+                |(decls, desc)| RawMergeOutput {
+                    confidence: compute_import_confidence(all_imports(&decls), true),
+                    items: decls,
+                    description: desc,
+                },
+            ),
         );
     }
 
@@ -246,7 +245,7 @@ pub(super) fn merge_three_way(
                         if source_equal(l, r) {
                             merged.push((*l).clone());
                         } else {
-                            return None; // Conflict
+                            return Ok(None); // Conflict
                         }
                     }
                 }
@@ -254,13 +253,13 @@ pub(super) fn merge_three_way(
             // Deleted by one side -- respect deletion (unless modified by the other)
             (Some(b), Some(l), None) => {
                 if !source_equal(b, l) {
-                    return None; // Modified + deleted = conflict
+                    return Ok(None); // Modified + deleted = conflict
                 }
                 // Deleted by right, unchanged by left -- respect deletion
             }
             (Some(b), None, Some(r)) => {
                 if !source_equal(b, r) {
-                    return None; // Modified + deleted = conflict
+                    return Ok(None); // Modified + deleted = conflict
                 }
                 // Deleted by left, unchanged by right -- respect deletion
             }
@@ -271,7 +270,7 @@ pub(super) fn merge_three_way(
                 if source_equal(l, r) {
                     merged.push((*l).clone());
                 } else {
-                    return None; // Conflict
+                    return Ok(None); // Conflict
                 }
             }
             (None, Some(l), None) => {
@@ -290,11 +289,11 @@ pub(super) fn merge_three_way(
     };
 
     let confidence = compute_mixed_confidence(has_import_merge, false, true);
-    Some(MergedDeclarations {
-        declarations: merged,
+    Ok(Some(RawMergeOutput {
+        items: merged,
         confidence,
         description,
-    })
+    }))
 }
 
 #[cfg(test)]
@@ -315,23 +314,23 @@ mod tests {
     fn two_way_disjoint_functions() {
         let left = parse("function foo() {}");
         let right = parse("function bar() {}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 2);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 2);
     }
 
     #[test]
     fn two_way_identical_functions() {
         let left = parse("function foo() {}");
         let right = parse("function foo() {}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert_eq!(result.declarations.len(), 1);
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert_eq!(result.items.len(), 1);
     }
 
     #[test]
     fn two_way_conflicting_functions() {
         let left = parse("function foo() { return 1; }");
         let right = parse("function foo() { return 2; }");
-        let result = merge_two_way(&left, &right);
+        let result = merge_two_way(&left, &right).unwrap();
         assert!(result.is_none(), "conflicting functions should return None");
     }
 
@@ -340,15 +339,15 @@ mod tests {
         let base = parse("function foo() { return 1; }");
         let left = parse("function foo() { return 42; }");
         let right = parse("function foo() { return 1; }");
-        let result = merge_three_way(&base, &left, &right).unwrap();
-        assert!(result.declarations[0].source_text.contains("42"));
+        let result = merge_three_way(&base, &left, &right).unwrap().unwrap();
+        assert!(result.items[0].source_text.contains("42"));
     }
 
     #[test]
     fn mixed_imports_and_declarations() {
         let left = parse("import { A } from 'x';\nfunction foo() {}");
         let right = parse("import { B } from 'x';\nfunction bar() {}");
-        let result = merge_two_way(&left, &right).unwrap();
-        assert!(result.declarations.len() >= 3); // merged import + foo + bar
+        let result = merge_two_way(&left, &right).unwrap().unwrap();
+        assert!(result.items.len() >= 3); // merged import + foo + bar
     }
 }

--- a/crates/weavr-ast/src/mergers/typescript_merger/mod.rs
+++ b/crates/weavr-ast/src/mergers/typescript_merger/mod.rs
@@ -18,6 +18,7 @@ use std::path::Path;
 use weavr_core::{ConflictHunk, Language};
 
 use crate::error::AstError;
+use crate::mergers::common::try_merge_ast;
 use crate::{AstMergeResult, AstMerger};
 
 use self::format::format_declarations;
@@ -50,41 +51,15 @@ impl AstMerger for TypeScriptMerger {
     }
 
     fn try_merge(&self, hunk: &ConflictHunk) -> Result<Option<AstMergeResult>, AstError> {
-        let left = match parse_fragment(&hunk.left.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let right = match parse_fragment(&hunk.right.text) {
-            ParsedFragment::Declarations(decls) => decls,
-            ParsedFragment::Unparsable => return Ok(None),
-        };
-
-        let base = if let Some(ref base_content) = hunk.base {
-            match parse_fragment(&base_content.text) {
+        try_merge_ast(
+            hunk,
+            |text| match parse_fragment(text) {
                 ParsedFragment::Declarations(decls) => Some(decls),
                 ParsedFragment::Unparsable => None,
-            }
-        } else {
-            None
-        };
-
-        let result = if let Some(base_decls) = base {
-            merge_three_way(&base_decls, &left, &right)
-        } else {
-            merge_two_way(&left, &right)
-        };
-
-        let Some(result) = result else {
-            return Ok(None);
-        };
-
-        let content = format_declarations(&result.declarations);
-
-        Ok(Some(AstMergeResult {
-            content,
-            confidence: result.confidence,
-            description: result.description,
-        }))
+            },
+            |left, right| merge_two_way(left, right),
+            |base, left, right| merge_three_way(base, left, right),
+            |decls| Ok(format_declarations(decls)),
+        )
     }
 }


### PR DESCRIPTION
## Summary
- Adds generic `try_merge_ast<D>()` scaffold and `RawMergeOutput<D>` to `common.rs`, extracting the duplicated parse-dispatch-format control flow from all 4 AST mergers
- Replaces ~38-line `try_merge` bodies in Rust, C#, TypeScript, and Go mergers with ~10-line delegations
- Unifies per-merger `MergedItems`/`MergedDeclarations` types into shared `RawMergeOutput<D>`
- Upgrades C#/TS/Go merge functions to return `Result` for consistency with the Rust merger

Closes #130

## Test plan
- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` — all 770 tests pass
- [x] `cargo clippy --workspace --all-targets -- -D warnings` clean
- [x] `cargo fmt --all --check` clean