### PR TITLE
Split config.rs into loading, raw types, and validation modules (#134)

### DIFF
--- a/crates/weavr-cli/src/config/mod.rs
+++ b/crates/weavr-cli/src/config/mod.rs
@@ -1,0 +1,194 @@
+//! Configuration file loading and merging.
+//!
+//! Supports layered configuration (lowest to highest priority):
+//! 1. Compiled-in defaults
+//! 2. User config: `~/.config/weavr/config.toml` (XDG)
+//! 3. Project config: `.weavr.toml` in cwd
+//! 4. `--config PATH` explicit file
+//! 5. CLI flags (applied after `from_raw`)
+
+mod raw;
+mod validate;
+
+use std::path::{Path, PathBuf};
+
+use crate::cli::Strategy;
+
+pub use raw::{RawConfig, RawKeybindingsConfig};
+pub use validate::parse_theme_name;
+
+// Re-export raw sub-types used by tests in other modules (e.g. merge_driver).
+#[cfg(test)]
+pub use raw::RawStrategiesConfig;
+
+// ---------------------------------------------------------------------------
+// Errors
+// ---------------------------------------------------------------------------
+
+/// Error type for configuration loading and parsing.
+#[derive(Debug, thiserror::Error)]
+pub enum ConfigError {
+    #[error("failed to read config file {path}: {source}")]
+    ReadError {
+        path: PathBuf,
+        source: std::io::Error,
+    },
+
+    #[error("failed to parse config file {path}: {source}")]
+    ParseError {
+        path: PathBuf,
+        source: toml::de::Error,
+    },
+
+    #[error("invalid value for '{key}': '{value}' ({hint})")]
+    InvalidValue {
+        key: String,
+        value: String,
+        hint: String,
+    },
+}
+
+// ---------------------------------------------------------------------------
+// Resolved config
+// ---------------------------------------------------------------------------
+
+/// Fully resolved configuration with concrete, validated types.
+#[derive(Debug, Clone)]
+#[allow(clippy::struct_excessive_bools)] // Config structs are naturally boolean
+pub struct WeavrConfig {
+    pub theme: weavr_tui::theme::ThemeName,
+    pub default_strategy: Strategy,
+    pub deduplicate: bool,
+    pub fail_on_ambiguous: bool,
+    pub auto_stage: bool,
+    pub stage_prompt: bool,
+    #[cfg(feature = "jj")]
+    pub squash_after_resolve: bool,
+    #[cfg(feature = "ai")]
+    pub ai: weavr_ai::AiConfig,
+    #[cfg(feature = "ast")]
+    pub ast: weavr_ast::AstConfig,
+}
+
+// ---------------------------------------------------------------------------
+// Config loading
+// ---------------------------------------------------------------------------
+
+/// Returns the user-level config path: `~/.config/weavr/config.toml` (XDG).
+#[must_use]
+pub fn user_config_path() -> Option<PathBuf> {
+    directories::ProjectDirs::from("", "", "weavr")
+        .map(|dirs| dirs.config_dir().join("config.toml"))
+}
+
+/// Loads and merges configuration layers 1-4.
+///
+/// 1. Compiled-in defaults (empty `RawConfig`)
+/// 2. User config (`~/.config/weavr/config.toml`)
+/// 3. Project config (`.weavr.toml` in cwd)
+/// 4. Explicit `--config PATH` file
+pub fn load_config(cli_path: Option<&Path>) -> Result<RawConfig, ConfigError> {
+    let mut config = RawConfig::default();
+
+    // Layer 2: User config
+    if let Some(user_path) = user_config_path() {
+        if user_path.exists() {
+            let user_config = read_config_file(&user_path)?;
+            config = user_config.merge(config);
+        }
+    }
+
+    // Layer 3: Project config
+    let project_path = PathBuf::from(".weavr.toml");
+    if project_path.exists() {
+        let project_config = read_config_file(&project_path)?;
+        config = project_config.merge(config);
+    }
+
+    // Layer 4: Explicit --config file
+    if let Some(path) = cli_path {
+        let explicit_config = read_config_file(path)?;
+        config = explicit_config.merge(config);
+    }
+
+    Ok(config)
+}
+
+/// Reads and parses a single TOML config file.
+fn read_config_file(path: &Path) -> Result<RawConfig, ConfigError> {
+    let content = std::fs::read_to_string(path).map_err(|source| ConfigError::ReadError {
+        path: path.to_path_buf(),
+        source,
+    })?;
+
+    toml::from_str(&content).map_err(|source| ConfigError::ParseError {
+        path: path.to_path_buf(),
+        source,
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn user_config_path_returns_some() {
+        assert!(user_config_path().is_some());
+    }
+
+    #[test]
+    fn load_config_no_files() {
+        // Run from a tempdir so neither ~/.config/weavr/config.toml nor
+        // .weavr.toml can be accidentally picked up from the host.
+        let dir = tempfile::tempdir().unwrap();
+        let prev = std::env::current_dir().unwrap();
+        std::env::set_current_dir(dir.path()).unwrap();
+
+        let raw = load_config(None).unwrap();
+
+        std::env::set_current_dir(prev).unwrap();
+
+        // User config may exist on the host, but project config won't.
+        // With no explicit file, only the user layer (if any) contributes.
+        // At minimum, strategies and headless should be None since no
+        // .weavr.toml exists in the tempdir.
+        assert!(raw.strategies.is_none());
+        assert!(raw.headless.is_none());
+    }
+
+    #[test]
+    fn read_config_file_missing() {
+        let err = read_config_file(Path::new("/nonexistent/config.toml")).unwrap_err();
+        assert!(matches!(err, ConfigError::ReadError { .. }));
+    }
+
+    #[test]
+    fn read_config_file_invalid_toml() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("bad.toml");
+        std::fs::write(&path, "this is not valid { toml").unwrap();
+
+        let err = read_config_file(&path).unwrap_err();
+        assert!(matches!(err, ConfigError::ParseError { .. }));
+    }
+
+    #[test]
+    fn load_config_explicit_file() {
+        let dir = tempfile::tempdir().unwrap();
+        let path = dir.path().join("config.toml");
+        std::fs::write(
+            &path,
+            r#"
+[theme]
+name = "nord"
+"#,
+        )
+        .unwrap();
+
+        let raw = load_config(Some(&path)).unwrap();
+        assert_eq!(
+            raw.theme.as_ref().and_then(|t| t.name.as_deref()),
+            Some("nord")
+        );
+    }
+}

--- a/crates/weavr-cli/src/config/raw.rs
+++ b/crates/weavr-cli/src/config/raw.rs
@@ -1,45 +1,6 @@
-//! Configuration file loading and merging.
-//!
-//! Supports layered configuration (lowest to highest priority):
-//! 1. Compiled-in defaults
-//! 2. User config: `~/.config/weavr/config.toml` (XDG)
-//! 3. Project config: `.weavr.toml` in cwd
-//! 4. `--config PATH` explicit file
-//! 5. CLI flags (applied after `from_raw`)
-
 use std::collections::BTreeMap;
-use std::path::{Path, PathBuf};
 
 use serde::Deserialize;
-
-use crate::cli::Strategy;
-
-// ---------------------------------------------------------------------------
-// Errors
-// ---------------------------------------------------------------------------
-
-/// Error type for configuration loading and parsing.
-#[derive(Debug, thiserror::Error)]
-pub enum ConfigError {
-    #[error("failed to read config file {path}: {source}")]
-    ReadError {
-        path: PathBuf,
-        source: std::io::Error,
-    },
-
-    #[error("failed to parse config file {path}: {source}")]
-    ParseError {
-        path: PathBuf,
-        source: toml::de::Error,
-    },
-
-    #[error("invalid value for '{key}': '{value}' ({hint})")]
-    InvalidValue {
-        key: String,
-        value: String,
-        hint: String,
-    },
-}
 
 // ---------------------------------------------------------------------------
 // Raw (deserializable) config types — all Option for merge support
@@ -205,176 +166,6 @@ fn merge_option<T>(
     }
 }
 
-// ---------------------------------------------------------------------------
-// Resolved config
-// ---------------------------------------------------------------------------
-
-/// Fully resolved configuration with concrete, validated types.
-#[derive(Debug, Clone)]
-#[allow(clippy::struct_excessive_bools)] // Config structs are naturally boolean
-pub struct WeavrConfig {
-    pub theme: weavr_tui::theme::ThemeName,
-    pub default_strategy: Strategy,
-    pub deduplicate: bool,
-    pub fail_on_ambiguous: bool,
-    pub auto_stage: bool,
-    pub stage_prompt: bool,
-    #[cfg(feature = "jj")]
-    pub squash_after_resolve: bool,
-    #[cfg(feature = "ai")]
-    pub ai: weavr_ai::AiConfig,
-    #[cfg(feature = "ast")]
-    pub ast: weavr_ast::AstConfig,
-}
-
-impl WeavrConfig {
-    /// Resolves a [`RawConfig`] into a validated [`WeavrConfig`].
-    ///
-    /// Returns a [`ConfigError::InvalidValue`] for unrecognized theme names
-    /// or strategy names, with a hint listing valid values.
-    pub fn from_raw(raw: &RawConfig) -> Result<Self, ConfigError> {
-        let theme = match raw.theme.as_ref().and_then(|t| t.name.as_deref()) {
-            Some(name) => parse_theme_name(name)?,
-            None => weavr_tui::theme::ThemeName::default(),
-        };
-
-        let default_strategy = match raw.strategies.as_ref().and_then(|s| s.default.as_deref()) {
-            Some(name) => parse_strategy(name).ok_or_else(|| ConfigError::InvalidValue {
-                key: "strategies.default".into(),
-                value: name.into(),
-                hint: "valid strategies: left, right, both, ast, ai".into(),
-            })?,
-            None => Strategy::Left,
-        };
-
-        let deduplicate = raw
-            .strategies
-            .as_ref()
-            .and_then(|s| s.deduplicate)
-            .unwrap_or(false);
-
-        let fail_on_ambiguous = raw
-            .headless
-            .as_ref()
-            .and_then(|h| h.fail_on_ambiguous)
-            .unwrap_or(false);
-
-        let auto_stage = raw.git.as_ref().and_then(|g| g.auto_stage).unwrap_or(false);
-
-        let stage_prompt = raw
-            .git
-            .as_ref()
-            .and_then(|g| g.stage_prompt)
-            .unwrap_or(true);
-
-        #[cfg(feature = "jj")]
-        let squash_after_resolve = raw
-            .jj
-            .as_ref()
-            .and_then(|j| j.squash_after_resolve)
-            .unwrap_or(false);
-
-        Ok(Self {
-            theme,
-            default_strategy,
-            deduplicate,
-            fail_on_ambiguous,
-            auto_stage,
-            stage_prompt,
-            #[cfg(feature = "jj")]
-            squash_after_resolve,
-            #[cfg(feature = "ai")]
-            ai: raw.ai.clone().unwrap_or_default(),
-            #[cfg(feature = "ast")]
-            ast: raw.ast.clone().unwrap_or_default(),
-        })
-    }
-}
-
-/// Parses a theme name string, returning a helpful error with valid theme names on failure.
-pub fn parse_theme_name(s: &str) -> Result<weavr_tui::theme::ThemeName, ConfigError> {
-    s.parse::<weavr_tui::theme::ThemeName>().map_err(|_| {
-        let valid: Vec<_> = weavr_tui::theme::ThemeName::all()
-            .iter()
-            .map(ToString::to_string)
-            .collect();
-        ConfigError::InvalidValue {
-            key: "theme.name".into(),
-            value: s.into(),
-            hint: format!("valid themes: {}", valid.join(", ")),
-        }
-    })
-}
-
-/// Parses a strategy name string into a [`Strategy`] variant.
-fn parse_strategy(s: &str) -> Option<Strategy> {
-    match s.to_lowercase().as_str() {
-        "left" => Some(Strategy::Left),
-        "right" => Some(Strategy::Right),
-        "both" => Some(Strategy::Both),
-        "ast" => Some(Strategy::Ast),
-        "ai" => Some(Strategy::Ai),
-        _ => None,
-    }
-}
-
-// ---------------------------------------------------------------------------
-// Config loading
-// ---------------------------------------------------------------------------
-
-/// Returns the user-level config path: `~/.config/weavr/config.toml` (XDG).
-#[must_use]
-pub fn user_config_path() -> Option<PathBuf> {
-    directories::ProjectDirs::from("", "", "weavr")
-        .map(|dirs| dirs.config_dir().join("config.toml"))
-}
-
-/// Loads and merges configuration layers 1-4.
-///
-/// 1. Compiled-in defaults (empty `RawConfig`)
-/// 2. User config (`~/.config/weavr/config.toml`)
-/// 3. Project config (`.weavr.toml` in cwd)
-/// 4. Explicit `--config PATH` file
-pub fn load_config(cli_path: Option<&Path>) -> Result<RawConfig, ConfigError> {
-    let mut config = RawConfig::default();
-
-    // Layer 2: User config
-    if let Some(user_path) = user_config_path() {
-        if user_path.exists() {
-            let user_config = read_config_file(&user_path)?;
-            config = user_config.merge(config);
-        }
-    }
-
-    // Layer 3: Project config
-    let project_path = PathBuf::from(".weavr.toml");
-    if project_path.exists() {
-        let project_config = read_config_file(&project_path)?;
-        config = project_config.merge(config);
-    }
-
-    // Layer 4: Explicit --config file
-    if let Some(path) = cli_path {
-        let explicit_config = read_config_file(path)?;
-        config = explicit_config.merge(config);
-    }
-
-    Ok(config)
-}
-
-/// Reads and parses a single TOML config file.
-fn read_config_file(path: &Path) -> Result<RawConfig, ConfigError> {
-    let content = std::fs::read_to_string(path).map_err(|source| ConfigError::ReadError {
-        path: path.to_path_buf(),
-        source,
-    })?;
-
-    toml::from_str(&content).map_err(|source| ConfigError::ParseError {
-        path: path.to_path_buf(),
-        source,
-    })
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -466,72 +257,6 @@ mod tests {
     }
 
     #[test]
-    fn from_raw_defaults() {
-        let config = WeavrConfig::from_raw(&RawConfig::default()).unwrap();
-        assert_eq!(config.theme, weavr_tui::theme::ThemeName::Dark);
-        assert_eq!(config.default_strategy, Strategy::Left);
-        assert!(!config.deduplicate);
-        assert!(!config.fail_on_ambiguous);
-        assert!(!config.auto_stage);
-        assert!(config.stage_prompt);
-    }
-
-    #[test]
-    fn from_raw_valid_theme() {
-        let raw = RawConfig {
-            theme: Some(RawThemeConfig {
-                name: Some("nord".into()),
-            }),
-            ..RawConfig::default()
-        };
-        let config = WeavrConfig::from_raw(&raw).unwrap();
-        assert_eq!(config.theme, weavr_tui::theme::ThemeName::Nord);
-    }
-
-    #[test]
-    fn from_raw_invalid_theme() {
-        let raw = RawConfig {
-            theme: Some(RawThemeConfig {
-                name: Some("nonexistent".into()),
-            }),
-            ..RawConfig::default()
-        };
-        let err = WeavrConfig::from_raw(&raw).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("theme.name"));
-        assert!(msg.contains("nonexistent"));
-        assert!(msg.contains("valid themes:"));
-    }
-
-    #[test]
-    fn from_raw_valid_strategy() {
-        let raw = RawConfig {
-            strategies: Some(RawStrategiesConfig {
-                default: Some("right".into()),
-                deduplicate: None,
-            }),
-            ..RawConfig::default()
-        };
-        let config = WeavrConfig::from_raw(&raw).unwrap();
-        assert_eq!(config.default_strategy, Strategy::Right);
-    }
-
-    #[test]
-    fn from_raw_invalid_strategy() {
-        let raw = RawConfig {
-            strategies: Some(RawStrategiesConfig {
-                default: Some("invalid".into()),
-                deduplicate: None,
-            }),
-            ..RawConfig::default()
-        };
-        let err = WeavrConfig::from_raw(&raw).unwrap_err();
-        let msg = err.to_string();
-        assert!(msg.contains("strategies.default"));
-        assert!(msg.contains("invalid"));
-    }
-
-    #[test]
     fn parse_toml_roundtrip() {
         let toml_str = r#"
 [theme]
@@ -545,9 +270,9 @@ deduplicate = true
 fail_on_ambiguous = true
 "#;
         let raw: RawConfig = toml::from_str(toml_str).unwrap();
-        let config = WeavrConfig::from_raw(&raw).unwrap();
+        let config = crate::config::WeavrConfig::from_raw(&raw).unwrap();
         assert_eq!(config.theme, weavr_tui::theme::ThemeName::Dracula);
-        assert_eq!(config.default_strategy, Strategy::Both);
+        assert_eq!(config.default_strategy, crate::cli::Strategy::Both);
         assert!(config.deduplicate);
         assert!(config.fail_on_ambiguous);
     }
@@ -572,79 +297,6 @@ foo = "bar"
     fn parse_toml_empty() {
         let raw: RawConfig = toml::from_str("").unwrap();
         assert!(raw.theme.is_none());
-    }
-
-    #[test]
-    fn user_config_path_returns_some() {
-        assert!(user_config_path().is_some());
-    }
-
-    #[test]
-    fn parse_strategy_valid() {
-        assert_eq!(parse_strategy("left"), Some(Strategy::Left));
-        assert_eq!(parse_strategy("RIGHT"), Some(Strategy::Right));
-        assert_eq!(parse_strategy("Both"), Some(Strategy::Both));
-    }
-
-    #[test]
-    fn parse_strategy_invalid() {
-        assert_eq!(parse_strategy("unknown"), None);
-    }
-
-    #[test]
-    fn load_config_no_files() {
-        // Run from a tempdir so neither ~/.config/weavr/config.toml nor
-        // .weavr.toml can be accidentally picked up from the host.
-        let dir = tempfile::tempdir().unwrap();
-        let prev = std::env::current_dir().unwrap();
-        std::env::set_current_dir(dir.path()).unwrap();
-
-        let raw = load_config(None).unwrap();
-
-        std::env::set_current_dir(prev).unwrap();
-
-        // User config may exist on the host, but project config won't.
-        // With no explicit file, only the user layer (if any) contributes.
-        // At minimum, strategies and headless should be None since no
-        // .weavr.toml exists in the tempdir.
-        assert!(raw.strategies.is_none());
-        assert!(raw.headless.is_none());
-    }
-
-    #[test]
-    fn read_config_file_missing() {
-        let err = read_config_file(Path::new("/nonexistent/config.toml")).unwrap_err();
-        assert!(matches!(err, ConfigError::ReadError { .. }));
-    }
-
-    #[test]
-    fn read_config_file_invalid_toml() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("bad.toml");
-        std::fs::write(&path, "this is not valid { toml").unwrap();
-
-        let err = read_config_file(&path).unwrap_err();
-        assert!(matches!(err, ConfigError::ParseError { .. }));
-    }
-
-    #[test]
-    fn load_config_explicit_file() {
-        let dir = tempfile::tempdir().unwrap();
-        let path = dir.path().join("config.toml");
-        std::fs::write(
-            &path,
-            r#"
-[theme]
-name = "nord"
-"#,
-        )
-        .unwrap();
-
-        let raw = load_config(Some(&path)).unwrap();
-        assert_eq!(
-            raw.theme.as_ref().and_then(|t| t.name.as_deref()),
-            Some("nord")
-        );
     }
 
     #[test]
@@ -737,7 +389,7 @@ auto_stage = true
 stage_prompt = false
 ";
         let raw: RawConfig = toml::from_str(toml_str).unwrap();
-        let config = WeavrConfig::from_raw(&raw).unwrap();
+        let config = crate::config::WeavrConfig::from_raw(&raw).unwrap();
         assert!(config.auto_stage);
         assert!(!config.stage_prompt);
     }
@@ -763,6 +415,16 @@ stage_prompt = false
         let git = merged.git.unwrap();
         assert_eq!(git.auto_stage, Some(true));
         assert_eq!(git.stage_prompt, Some(false));
+    }
+
+    #[test]
+    fn no_keybindings_section_is_none() {
+        let toml_str = r#"
+[theme]
+name = "dark"
+"#;
+        let raw: RawConfig = toml::from_str(toml_str).unwrap();
+        assert!(raw.keybindings.is_none());
     }
 
     #[cfg(feature = "jj")]
@@ -796,35 +458,5 @@ squash_after_resolve = true
         let merged = higher.merge(lower);
         let jj = merged.jj.unwrap();
         assert_eq!(jj.squash_after_resolve, Some(true));
-    }
-
-    #[cfg(feature = "jj")]
-    #[test]
-    fn from_raw_jj_defaults() {
-        let config = WeavrConfig::from_raw(&RawConfig::default()).unwrap();
-        assert!(!config.squash_after_resolve);
-    }
-
-    #[cfg(feature = "jj")]
-    #[test]
-    fn from_raw_jj_squash_enabled() {
-        let raw = RawConfig {
-            jj: Some(RawJjConfig {
-                squash_after_resolve: Some(true),
-            }),
-            ..RawConfig::default()
-        };
-        let config = WeavrConfig::from_raw(&raw).unwrap();
-        assert!(config.squash_after_resolve);
-    }
-
-    #[test]
-    fn no_keybindings_section_is_none() {
-        let toml_str = r#"
-[theme]
-name = "dark"
-"#;
-        let raw: RawConfig = toml::from_str(toml_str).unwrap();
-        assert!(raw.keybindings.is_none());
     }
 }

--- a/crates/weavr-cli/src/config/validate.rs
+++ b/crates/weavr-cli/src/config/validate.rs
@@ -1,0 +1,202 @@
+use crate::cli::Strategy;
+
+use super::raw::RawConfig;
+use super::ConfigError;
+use super::WeavrConfig;
+
+impl WeavrConfig {
+    /// Resolves a [`RawConfig`] into a validated [`WeavrConfig`].
+    ///
+    /// Returns a [`ConfigError::InvalidValue`] for unrecognized theme names
+    /// or strategy names, with a hint listing valid values.
+    pub fn from_raw(raw: &RawConfig) -> Result<Self, ConfigError> {
+        let theme = match raw.theme.as_ref().and_then(|t| t.name.as_deref()) {
+            Some(name) => parse_theme_name(name)?,
+            None => weavr_tui::theme::ThemeName::default(),
+        };
+
+        let default_strategy = match raw.strategies.as_ref().and_then(|s| s.default.as_deref()) {
+            Some(name) => parse_strategy(name).ok_or_else(|| ConfigError::InvalidValue {
+                key: "strategies.default".into(),
+                value: name.into(),
+                hint: "valid strategies: left, right, both, ast, ai".into(),
+            })?,
+            None => Strategy::Left,
+        };
+
+        let deduplicate = raw
+            .strategies
+            .as_ref()
+            .and_then(|s| s.deduplicate)
+            .unwrap_or(false);
+
+        let fail_on_ambiguous = raw
+            .headless
+            .as_ref()
+            .and_then(|h| h.fail_on_ambiguous)
+            .unwrap_or(false);
+
+        let auto_stage = raw.git.as_ref().and_then(|g| g.auto_stage).unwrap_or(false);
+
+        let stage_prompt = raw
+            .git
+            .as_ref()
+            .and_then(|g| g.stage_prompt)
+            .unwrap_or(true);
+
+        #[cfg(feature = "jj")]
+        let squash_after_resolve = raw
+            .jj
+            .as_ref()
+            .and_then(|j| j.squash_after_resolve)
+            .unwrap_or(false);
+
+        Ok(Self {
+            theme,
+            default_strategy,
+            deduplicate,
+            fail_on_ambiguous,
+            auto_stage,
+            stage_prompt,
+            #[cfg(feature = "jj")]
+            squash_after_resolve,
+            #[cfg(feature = "ai")]
+            ai: raw.ai.clone().unwrap_or_default(),
+            #[cfg(feature = "ast")]
+            ast: raw.ast.clone().unwrap_or_default(),
+        })
+    }
+}
+
+/// Parses a theme name string, returning a helpful error with valid theme names on failure.
+pub fn parse_theme_name(s: &str) -> Result<weavr_tui::theme::ThemeName, ConfigError> {
+    s.parse::<weavr_tui::theme::ThemeName>().map_err(|_| {
+        let valid: Vec<_> = weavr_tui::theme::ThemeName::all()
+            .iter()
+            .map(ToString::to_string)
+            .collect();
+        ConfigError::InvalidValue {
+            key: "theme.name".into(),
+            value: s.into(),
+            hint: format!("valid themes: {}", valid.join(", ")),
+        }
+    })
+}
+
+/// Parses a strategy name string into a [`Strategy`] variant.
+fn parse_strategy(s: &str) -> Option<Strategy> {
+    match s.to_lowercase().as_str() {
+        "left" => Some(Strategy::Left),
+        "right" => Some(Strategy::Right),
+        "both" => Some(Strategy::Both),
+        "ast" => Some(Strategy::Ast),
+        "ai" => Some(Strategy::Ai),
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::config::raw::{RawConfig, RawStrategiesConfig, RawThemeConfig};
+
+    #[test]
+    fn from_raw_defaults() {
+        let config = WeavrConfig::from_raw(&RawConfig::default()).unwrap();
+        assert_eq!(config.theme, weavr_tui::theme::ThemeName::Dark);
+        assert_eq!(config.default_strategy, Strategy::Left);
+        assert!(!config.deduplicate);
+        assert!(!config.fail_on_ambiguous);
+        assert!(!config.auto_stage);
+        assert!(config.stage_prompt);
+    }
+
+    #[test]
+    fn from_raw_valid_theme() {
+        let raw = RawConfig {
+            theme: Some(RawThemeConfig {
+                name: Some("nord".into()),
+            }),
+            ..RawConfig::default()
+        };
+        let config = WeavrConfig::from_raw(&raw).unwrap();
+        assert_eq!(config.theme, weavr_tui::theme::ThemeName::Nord);
+    }
+
+    #[test]
+    fn from_raw_invalid_theme() {
+        let raw = RawConfig {
+            theme: Some(RawThemeConfig {
+                name: Some("nonexistent".into()),
+            }),
+            ..RawConfig::default()
+        };
+        let err = WeavrConfig::from_raw(&raw).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("theme.name"));
+        assert!(msg.contains("nonexistent"));
+        assert!(msg.contains("valid themes:"));
+    }
+
+    #[test]
+    fn from_raw_valid_strategy() {
+        let raw = RawConfig {
+            strategies: Some(RawStrategiesConfig {
+                default: Some("right".into()),
+                deduplicate: None,
+            }),
+            ..RawConfig::default()
+        };
+        let config = WeavrConfig::from_raw(&raw).unwrap();
+        assert_eq!(config.default_strategy, Strategy::Right);
+    }
+
+    #[test]
+    fn from_raw_invalid_strategy() {
+        let raw = RawConfig {
+            strategies: Some(RawStrategiesConfig {
+                default: Some("invalid".into()),
+                deduplicate: None,
+            }),
+            ..RawConfig::default()
+        };
+        let err = WeavrConfig::from_raw(&raw).unwrap_err();
+        let msg = err.to_string();
+        assert!(msg.contains("strategies.default"));
+        assert!(msg.contains("invalid"));
+    }
+
+    #[test]
+    fn parse_strategy_valid() {
+        assert_eq!(parse_strategy("left"), Some(Strategy::Left));
+        assert_eq!(parse_strategy("RIGHT"), Some(Strategy::Right));
+        assert_eq!(parse_strategy("Both"), Some(Strategy::Both));
+    }
+
+    #[test]
+    fn parse_strategy_invalid() {
+        assert_eq!(parse_strategy("unknown"), None);
+    }
+
+    #[cfg(feature = "jj")]
+    #[test]
+    fn from_raw_jj_defaults() {
+        let config = WeavrConfig::from_raw(&RawConfig::default()).unwrap();
+        assert!(!config.squash_after_resolve);
+    }
+
+    #[cfg(feature = "jj")]
+    #[test]
+    fn from_raw_jj_squash_enabled() {
+        use crate::config::raw::RawJjConfig;
+
+        let raw = RawConfig {
+            jj: Some(RawJjConfig {
+                squash_after_resolve: Some(true),
+            }),
+            ..RawConfig::default()
+        };
+        let config = WeavrConfig::from_raw(&raw).unwrap();
+        assert!(config.squash_after_resolve);
+    }
+}


### PR DESCRIPTION
## Summary

- Split `crates/weavr-cli/src/config.rs` (830 lines) into a `config/` module directory with three focused files:
  - `mod.rs` — module glue, re-exports, `ConfigError`, `WeavrConfig` struct, config loading/IO
  - `raw.rs` — all `Raw*Config` TOML deserialization structs, `RawConfig::merge()`, `merge_option()`
  - `validate.rs` — `WeavrConfig::from_raw()`, `parse_theme_name()`, `parse_strategy()`
- Merged the originally proposed `merge.rs` into `raw.rs` since `merge()` is a small impl on `RawConfig`
- Pure structural refactor — no behavior changes

Closes #134

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (all 42 config tests)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes