### PR TITLE
Split pane rendering from document building in pane.rs

### DIFF
--- a/crates/weavr-tui/src/ui/document.rs
+++ b/crates/weavr-tui/src/ui/document.rs
@@ -15,7 +15,7 @@ use crate::ast::AstState;
 use crate::diff::{compute_line_diffs, compute_word_diffs, DiffConfig, DiffLine};
 use crate::highlight::{self, HighlightedDocument};
 
-use super::pane::PaneSide;
+use super::PaneSide;
 
 /// Builds the full document content for a side pane (left or right).
 pub(super) fn build_side_document<'a>(
@@ -435,7 +435,7 @@ fn build_highlighted_line(
 /// Uses the counterpart text to compute word-level diffs and renders
 /// each word segment with appropriate styling: base diff style for
 /// unchanged words, `theme.diff.modified` for changed words.
-pub(super) fn build_word_diff_line(
+fn build_word_diff_line(
     line_number: usize,
     diff_line: &DiffLine,
     side: PaneSide,
@@ -487,4 +487,30 @@ pub(super) fn build_word_diff_line(
     }
 
     Line::from(spans)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::diff::DiffLine;
+    use crate::theme::{Theme, ThemeName};
+
+    #[test]
+    fn word_diff_line_produces_multiple_spans() {
+        let theme = Theme::from(ThemeName::Dark);
+        let diff_line = DiffLine::with_counterpart(
+            "hello world",
+            ChangeTag::Delete,
+            "hello universe".to_string(),
+        );
+
+        let line = build_word_diff_line(1, &diff_line, PaneSide::Left, &theme, false);
+
+        // Should have: line number span + word spans (more than 2 total)
+        assert!(
+            line.spans.len() > 2,
+            "Expected multiple spans for word diff, got {}",
+            line.spans.len()
+        );
+    }
 }

--- a/crates/weavr-tui/src/ui/mod.rs
+++ b/crates/weavr-tui/src/ui/mod.rs
@@ -9,10 +9,38 @@ mod pane;
 
 pub use layout::{calculate_layout, PaneAreas};
 
+use crate::FocusedPane;
 use ratatui::Frame;
 
 use crate::input::Dialog;
 use crate::App;
+
+/// Which side of the conflict to render.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum PaneSide {
+    /// Left side (`ours`/`HEAD`).
+    Left,
+    /// Right side (`theirs`/`MERGE_HEAD`).
+    Right,
+}
+
+impl PaneSide {
+    /// Returns the title for this side.
+    fn title(self) -> &'static str {
+        match self {
+            Self::Left => "Left (Ours)",
+            Self::Right => "Right (Theirs)",
+        }
+    }
+
+    /// Returns the corresponding `FocusedPane`.
+    fn focused_pane(self) -> FocusedPane {
+        match self {
+            Self::Left => FocusedPane::Left,
+            Self::Right => FocusedPane::Right,
+        }
+    }
+}
 
 /// Renders the entire UI to the frame.
 pub fn draw(frame: &mut Frame, app: &App) {

--- a/crates/weavr-tui/src/ui/pane.rs
+++ b/crates/weavr-tui/src/ui/pane.rs
@@ -18,33 +18,7 @@ use crate::input::InputMode;
 use crate::{App, FocusedPane};
 
 use super::document::{build_base_document, build_result_document, build_side_document};
-
-/// Which side of the conflict to render.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum PaneSide {
-    /// Left side (`ours`/`HEAD`).
-    Left,
-    /// Right side (`theirs`/`MERGE_HEAD`).
-    Right,
-}
-
-impl PaneSide {
-    /// Returns the title for this side.
-    fn title(self) -> &'static str {
-        match self {
-            Self::Left => "Left (Ours)",
-            Self::Right => "Right (Theirs)",
-        }
-    }
-
-    /// Returns the corresponding `FocusedPane`.
-    fn focused_pane(self) -> FocusedPane {
-        match self {
-            Self::Left => FocusedPane::Left,
-            Self::Right => FocusedPane::Right,
-        }
-    }
-}
+use super::PaneSide;
 
 /// Renders the left pane showing the "ours" side of the document.
 pub fn render_left_pane(frame: &mut Frame, area: Rect, app: &App) {
@@ -586,29 +560,5 @@ mod tests {
                 })
                 .unwrap();
         }
-    }
-
-    #[test]
-    fn word_diff_line_produces_multiple_spans() {
-        use super::super::document::build_word_diff_line;
-        use crate::diff::DiffLine;
-        use crate::theme::Theme;
-        use similar::ChangeTag;
-
-        let theme = Theme::from(ThemeName::Dark);
-        let diff_line = DiffLine::with_counterpart(
-            "hello world",
-            ChangeTag::Delete,
-            "hello universe".to_string(),
-        );
-
-        let line = build_word_diff_line(1, &diff_line, PaneSide::Left, &theme, false);
-
-        // Should have: line number span + word spans (more than 2 total)
-        assert!(
-            line.spans.len() > 2,
-            "Expected multiple spans for word diff, got {}",
-            line.spans.len()
-        );
     }
 }


### PR DESCRIPTION
## Summary

Closes #132

- Extracted document building functions (`build_side_document`, `build_base_document`, `build_result_document`) and line-building helpers into a new `ui/document.rs` module
- `ui/pane.rs` now contains only widget/frame rendering functions (borders, blocks, scrolling, cursor positioning)
- Added `mod document` to `ui/mod.rs`

## Test plan

- [x] `cargo build --workspace` passes
- [x] `cargo test --workspace` passes (no test changes beyond import paths)
- [x] `cargo clippy --workspace --all-targets -- -D warnings` passes
- [x] `cargo fmt --all --check` passes