### PR TITLE
Fix: require explicit write before saving resolved files

### DIFF
--- a/crates/weavr-cli/src/main.rs
+++ b/crates/weavr-cli/src/main.rs
@@ -344,12 +344,16 @@ fn run(cli: &Cli) -> Result<i32, CliError> {
             }
         } else {
             any_unresolved = true;
-            eprintln!(
-                "{}: exited with {}/{} hunks unresolved",
-                result.path.display(),
-                result.total_hunks - result.hunks_resolved,
-                result.total_hunks
-            );
+            let unresolved = result.total_hunks - result.hunks_resolved;
+            if unresolved == 0 {
+                eprintln!("{}: quit without saving", result.path.display());
+            } else {
+                eprintln!(
+                    "{}: exited with {unresolved}/{} hunks unresolved",
+                    result.path.display(),
+                    result.total_hunks
+                );
+            }
         }
     }
 

--- a/crates/weavr-cli/src/tui.rs
+++ b/crates/weavr-cli/src/tui.rs
@@ -92,6 +92,7 @@ pub fn process_file(
     // Extract preferences before taking session
     let stage_requested = app.stage_requested();
     let partial_write = app.partial_write_requested();
+    let write_requested = app.write_requested();
 
     // Extract session and check resolution state
     let session = app
@@ -103,7 +104,7 @@ pub fn process_file(
         .filter(|h| matches!(h.state, weavr_core::HunkState::Resolved(_)))
         .count();
 
-    if session.is_fully_resolved() {
+    if session.is_fully_resolved() && write_requested {
         // Complete the lifecycle to get the merged content
         let mut session = session;
         session.apply()?;

--- a/crates/weavr-tui/src/dialog.rs
+++ b/crates/weavr-tui/src/dialog.rs
@@ -81,12 +81,15 @@ pub fn confirm_staging(app: &mut App) {
 }
 
 /// Denies staging in the staging prompt dialog.
+///
+/// The user still intends to write — they're only declining the stage step.
 pub fn deny_staging(app: &mut App) {
     let multi = app.is_multi_file();
     close_dialog(app);
     if multi {
         app.complete_current_and_advance();
     } else {
+        app.write_requested = true;
         app.quit();
     }
 }

--- a/crates/weavr-tui/src/lib.rs
+++ b/crates/weavr-tui/src/lib.rs
@@ -124,6 +124,8 @@ pub struct App {
     pub(crate) workspace: Option<workspace::Workspace>,
     /// Whether a partial write was requested (single-file mode).
     pub(crate) partial_write: bool,
+    /// Whether the user explicitly requested a write (`:w`, `:wq`, `:wa`, or `:q` when resolved).
+    pub(crate) write_requested: bool,
 }
 
 impl App {
@@ -160,6 +162,7 @@ impl App {
             stage_prompt: false,
             workspace: None,
             partial_write: false,
+            write_requested: false,
         }
     }
 
@@ -196,6 +199,7 @@ impl App {
             stage_prompt: false,
             workspace: None,
             partial_write: false,
+            write_requested: false,
         }
     }
 
@@ -474,6 +478,7 @@ impl App {
             self.mark_current_written();
             self.set_status_message("Saved. Use :n to continue.");
         } else {
+            self.write_requested = true;
             self.quit();
         }
     }
@@ -487,6 +492,7 @@ impl App {
             self.stage_current_file();
             self.complete_current_and_advance();
         } else {
+            self.write_requested = true;
             self.stage_requested = true;
             self.quit();
         }
@@ -504,8 +510,10 @@ impl App {
                 self.complete_current_and_advance();
             }
         } else if self.stage_prompt {
+            self.write_requested = true;
             dialog::show_staging_prompt(self);
         } else {
+            self.write_requested = true;
             self.quit();
         }
     }
@@ -565,6 +573,7 @@ impl App {
             let count = self.unresolved_count();
             self.set_status_message(&format!("{count} unresolved hunks. Use :q! to force quit"));
         } else {
+            self.write_requested = true;
             self.quit();
         }
     }
@@ -607,6 +616,12 @@ impl App {
     #[must_use]
     pub fn partial_write_requested(&self) -> bool {
         self.partial_write
+    }
+
+    /// Returns whether the user explicitly requested a write.
+    #[must_use]
+    pub fn write_requested(&self) -> bool {
+        self.write_requested
     }
 
     /// Sets whether to show the staging prompt on `:wq`.

--- a/crates/weavr-tui/src/lib.rs
+++ b/crates/weavr-tui/src/lib.rs
@@ -1396,4 +1396,49 @@ mod tests {
         let msg = &app.status_message().unwrap().0;
         assert!(msg.contains("No other files"));
     }
+
+    #[test]
+    fn write_requested_false_by_default() {
+        let app = App::new();
+        assert!(!app.write_requested());
+    }
+
+    #[test]
+    fn force_quit_does_not_set_write_requested() {
+        let mut app = App::new();
+        app.quit();
+        assert!(app.should_quit());
+        assert!(!app.write_requested());
+    }
+
+    #[test]
+    fn try_quit_sets_write_requested_when_no_unresolved_hunks() {
+        use std::path::PathBuf;
+
+        // Session with no hunks (clean file) — try_quit should set write_requested
+        let content = "no conflicts here";
+        let session =
+            weavr_core::MergeSession::from_conflicted(content, PathBuf::from("clean.rs")).unwrap();
+        let mut app = App::new();
+        app.set_session(session);
+
+        app.try_quit();
+        assert!(app.should_quit());
+        assert!(app.write_requested());
+    }
+
+    #[test]
+    fn try_quit_does_not_set_write_requested_when_unresolved() {
+        use std::path::PathBuf;
+
+        let content = "<<<<<<< HEAD\nleft\n=======\nright\n>>>>>>> branch\n";
+        let session =
+            weavr_core::MergeSession::from_conflicted(content, PathBuf::from("test.rs")).unwrap();
+        let mut app = App::new();
+        app.set_session(session);
+
+        app.try_quit();
+        assert!(!app.should_quit()); // warns instead of quitting
+        assert!(!app.write_requested());
+    }
 }


### PR DESCRIPTION
## Summary
- Adds a `write_requested` flag to the TUI `App` that tracks whether the user explicitly invoked a write command
- Gates single-file writes on this flag, preventing accidental saves when the user force-quits (`q`) after inadvertently resolving hunks
- The flag is set by `:w`, `:wq`, `:wa`, `:q` (when fully resolved), and the staging dialog — but NOT by bare `q` force-quit

## Problem
If a user accidentally pressed a resolution key (`o`/`t`/`b`) on a single-hunk file then pressed `q` to quit, the file was written with markers removed — even though they never typed `:w` or `:wq`. This could silently clear git's unmerged state.

## Test plan
- [x] `cargo build --workspace` — builds clean
- [x] `cargo clippy --workspace --all-targets -- -D warnings` — clean
- [x] `cargo fmt --all -- --check` — clean
- [x] Existing tests all pass
- [ ] Manual: resolve a hunk then press `q` — file should NOT be written
- [ ] Manual: resolve a hunk then `:wq` — file SHOULD be written
- [ ] Manual: resolve all hunks then `:q` — file SHOULD be written